### PR TITLE
Allow fetching organizational repositories

### DIFF
--- a/src/main/java/org/jenkinsci/plugin/gitea/GiteaSCMNavigator.java
+++ b/src/main/java/org/jenkinsci/plugin/gitea/GiteaSCMNavigator.java
@@ -139,11 +139,9 @@ public class GiteaSCMNavigator extends SCMNavigator {
                 .withTraits(traits)
                 .newRequest(this, observer);
              GiteaConnection c = gitea(observer.getContext()).open()) {
-            giteaOwner = c.fetchUser(repoOwner);
-            if (StringUtils.isBlank(giteaOwner.getEmail())) {
-                giteaOwner = c.fetchOrganization(repoOwner);
-            }
+            giteaOwner = c.fetchOwner(repoOwner);
             List<GiteaRepository> repositories = c.fetchRepositories(giteaOwner);
+
             int count = 0;
             observer.getListener().getLogger().format("%n  Checking repositories...%n");
             Set<Long> seen = new HashSet<>();

--- a/src/main/java/org/jenkinsci/plugin/gitea/GiteaSCMSource.java
+++ b/src/main/java/org/jenkinsci/plugin/gitea/GiteaSCMSource.java
@@ -90,13 +90,7 @@ import jenkins.scm.impl.trait.Selection;
 import org.apache.commons.lang.StringUtils;
 import org.jenkins.ui.icon.Icon;
 import org.jenkins.ui.icon.IconSet;
-import org.jenkinsci.plugin.gitea.client.api.Gitea;
-import org.jenkinsci.plugin.gitea.client.api.GiteaAuth;
-import org.jenkinsci.plugin.gitea.client.api.GiteaBranch;
-import org.jenkinsci.plugin.gitea.client.api.GiteaConnection;
-import org.jenkinsci.plugin.gitea.client.api.GiteaIssueState;
-import org.jenkinsci.plugin.gitea.client.api.GiteaPullRequest;
-import org.jenkinsci.plugin.gitea.client.api.GiteaRepository;
+import org.jenkinsci.plugin.gitea.client.api.*;
 import org.jenkinsci.plugin.gitea.servers.GiteaServer;
 import org.jenkinsci.plugin.gitea.servers.GiteaServers;
 import org.kohsuke.stapler.AncestorInPath;
@@ -785,7 +779,9 @@ public class GiteaSCMSource extends AbstractGitSCMSource {
             try (GiteaConnection c = Gitea.server(serverUrl)
                     .as(AuthenticationTokens.convert(GiteaAuth.class, credentials))
                     .open()) {
-                for (GiteaRepository r : c.fetchRepositories(repoOwner)) {
+                GiteaOwner owner = c.fetchOwner(repoOwner);
+                List<GiteaRepository> repositories = c.fetchRepositories(owner);
+                for (GiteaRepository r : repositories) {
                     result.add(r.getName());
                 }
                 return result;

--- a/src/main/java/org/jenkinsci/plugin/gitea/client/api/GiteaConnection.java
+++ b/src/main/java/org/jenkinsci/plugin/gitea/client/api/GiteaConnection.java
@@ -41,6 +41,8 @@ public interface GiteaConnection extends AutoCloseable {
 
     GiteaUser fetchCurrentUser() throws IOException, InterruptedException;
 
+    GiteaOwner fetchOwner(String name) throws IOException, InterruptedException;
+
     GiteaUser fetchUser(String name) throws IOException, InterruptedException;
 
     GiteaOrganization fetchOrganization(String name) throws IOException, InterruptedException;
@@ -54,6 +56,8 @@ public interface GiteaConnection extends AutoCloseable {
     List<GiteaRepository> fetchRepositories(String username) throws IOException, InterruptedException;
 
     List<GiteaRepository> fetchRepositories(GiteaOwner owner) throws IOException, InterruptedException;
+
+    List<GiteaRepository> fetchOrganizationRepositories(GiteaOwner owner) throws IOException, InterruptedException;
 
     GiteaBranch fetchBranch(String username, String repository, String name) throws IOException, InterruptedException;
 

--- a/src/main/java/org/jenkinsci/plugin/gitea/client/impl/DefaultGiteaConnection.java
+++ b/src/main/java/org/jenkinsci/plugin/gitea/client/impl/DefaultGiteaConnection.java
@@ -154,7 +154,8 @@ class DefaultGiteaConnection implements GiteaConnection {
             }
         }
         catch (GiteaHttpStatusException e) {
-            // When it's NotFound, owner might be a user, so only rethrow when 404
+            // When it's NotFound, owner might be a user, so only rethrow when not 404
+            // Every other non 200 status code should be thrown again by fetchUser()
             if(e.getStatusCode() != 404) {
                 throw e;
             }

--- a/src/test/java/org/jenkinsci/plugin/gitea/client/mock/MockGiteaConnection.java
+++ b/src/test/java/org/jenkinsci/plugin/gitea/client/mock/MockGiteaConnection.java
@@ -150,6 +150,12 @@ public class MockGiteaConnection implements GiteaConnection {
     }
 
     @Override
+    public GiteaOwner fetchOwner(String name) throws IOException, InterruptedException {
+        GiteaOrganization organization = organizations.get(name);
+        return organization != null ? organization : notFoundIfNull(users.get(name));
+    }
+
+    @Override
     public GiteaUser fetchUser(String name) throws IOException, InterruptedException {
         return notFoundIfNull(users.get(name)).clone();
     }
@@ -190,6 +196,11 @@ public class MockGiteaConnection implements GiteaConnection {
 
     @Override
     public List<GiteaRepository> fetchRepositories(GiteaOwner owner) throws IOException, InterruptedException {
+        return fetchRepositories(owner.getUsername());
+    }
+
+    @Override
+    public List<GiteaRepository> fetchOrganizationRepositories(GiteaOwner owner) throws IOException, InterruptedException {
         return fetchRepositories(owner.getUsername());
     }
 


### PR DESCRIPTION
This PR fixes the [issue](https://issues.jenkins-ci.org/browse/JENKINS-52112) about fetching organizational repositories for me.

This way the user doesn't have to be an administrator.