### PR TITLE
[FIXED JENKINS-61996] Check for not specified port in SSH URI

### DIFF
--- a/src/main/java/org/jenkinsci/plugin/gitea/GiteaSCMBuilder.java
+++ b/src/main/java/org/jenkinsci/plugin/gitea/GiteaSCMBuilder.java
@@ -164,7 +164,7 @@ public class GiteaSCMBuilder extends GitSCMBuilder<GiteaSCMBuilder> {
                 }
                 URI sshUri = URI.create(sshRemote);
                 return UriTemplate.buildFromTemplate(
-                        "ssh://git@" + sshUri.getHost() + (sshUri.getPort() != 22 ? ":" + sshUri.getPort() : "")
+                        "ssh://git@" + sshUri.getHost() + (sshUri.getPort() != 22 && sshUri.getPort() != -1 ? ":" + sshUri.getPort() : "")
                 )
                         .path(UriTemplateBuilder.var("owner"))
                         .path(UriTemplateBuilder.var("repository"))


### PR DESCRIPTION
As specified in documentation:
https://docs.oracle.com/javase/7/docs/api/java/net/URI.html#getPort()
getPort() returns "The port component of this URI, or -1 if the port is undefined"
I have added the condition for -1 so the uri doesn't end up with the port -1.