### PR TITLE
Remove unnecessary branch retrieval loop on build startup phase

### DIFF
--- a/src/main/java/org/jenkinsci/plugin/gitea/client/impl/DefaultGiteaConnection.java
+++ b/src/main/java/org/jenkinsci/plugin/gitea/client/impl/DefaultGiteaConnection.java
@@ -260,25 +260,17 @@ class DefaultGiteaConnection implements GiteaConnection {
     @Override
     public GiteaBranch fetchBranch(String username, String repository, String name)
             throws IOException, InterruptedException {
-        if (name.indexOf('/') != -1) {
-            // TODO remove hack once https://github.com/go-gitea/gitea/issues/2088 is fixed
-            for (GiteaBranch b : fetchBranches(username, repository)) {
-                if (name.equals(b.getName())) {
-                    return b;
-                }
-            }
-        }
         return getObject(
                 api()
                         .literal("/repos")
                         .path(UriTemplateBuilder.var("username"))
                         .path(UriTemplateBuilder.var("repository"))
                         .literal("/branches")
-                        .path(UriTemplateBuilder.var("name", true))
+                        .path(UriTemplateBuilder.var("name"))
                         .build()
                         .set("username", username)
                         .set("repository", repository)
-                        .set("name", StringUtils.split(name, '/')),
+                        .set("name", name),
                 GiteaBranch.class
         );
     }


### PR DESCRIPTION
The mentioned Gitea bug https://github.com/go-gitea/gitea/issues/2088 was fixed years ago. I always use branch patterns like `<bug|feature|task>/<summarized-content>` which is exactly the kind of branches for which all branches are fetched to get the only one that is needed. In my environment this takes about 20 seconds, speaking of repositories with more than 400 branches.

With this fix, this part of the build takes only 200ms.

Fixes: https://issues.jenkins.io/browse/JENKINS-65796