### PR TITLE
SCMSource: Check task authentication context when looking forcredentials

### DIFF
--- a/src/main/java/org/jenkinsci/plugin/gitea/GiteaSCMSource.java
+++ b/src/main/java/org/jenkinsci/plugin/gitea/GiteaSCMSource.java
@@ -662,11 +662,14 @@ public class GiteaSCMSource extends AbstractGitSCMSource {
     }
 
     public StandardCredentials credentials() {
+        SCMSourceOwner owner = getOwner();
         return CredentialsMatchers.firstOrNull(
                 CredentialsProvider.lookupCredentials(
                         StandardCredentials.class,
-                        getOwner(),
-                        Jenkins.getAuthentication(),
+                        owner,
+                        owner instanceof Queue.Task ?
+                                ((Queue.Task) owner).getDefaultAuthentication()
+                                : ACL.SYSTEM,
                         URIRequirementBuilder.fromUri(serverUrl).build()
                 ),
                 CredentialsMatchers.allOf(


### PR DESCRIPTION
GiteaSCMSource was sometimes using  the authenticated user associated with the request. 
This was causing occasional requests to be sent without authorization headers, and receiving 404 responses.
This could happen by manually triggering a single branch in a multi-branch pipeline project, or replaying a job. Triggering a job that lanches a parametrized build of a branch job also triggered the issue.

This change checks for Queue.Task instance, and fallbacks to the the System credential. This is what is done elsewhere.
The user associated with the request is this not used anymore when retrieving credentials by id.

Fixes JENKINS-62326
