### PR TITLE
FIX JENKINS-63048

### DIFF
--- a/src/main/java/org/jenkinsci/plugin/gitea/client/impl/DefaultGiteaConnection.java
+++ b/src/main/java/org/jenkinsci/plugin/gitea/client/impl/DefaultGiteaConnection.java
@@ -45,7 +45,11 @@ import java.util.Collections;
 import java.util.EnumSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import javax.net.ssl.HttpsURLConnection;
 import jenkins.model.Jenkins;
 import org.apache.commons.codec.binary.Base64;
@@ -959,20 +963,33 @@ class DefaultGiteaConnection implements GiteaConnection {
         }
     }
 
+    private Pattern nextPagePattern = Pattern.compile("<(.*)>;\s*rel=\"next\"");
+
     private <T> List<T> getList(UriTemplate template, final Class<T> modelClass)
             throws IOException, InterruptedException {
-        HttpURLConnection connection = openConnection(template);
+        return getList(template.expand(), modelClass);
+    }
+
+    private <T> List<T> getList(String url, final Class<T> modelClass) throws IOException, InterruptedException {
+        HttpURLConnection connection = openConnection(url);
         withAuthentication(connection);
         try {
             connection.connect();
             int status = connection.getResponseCode();
+
             if (status / 100 == 2) {
+                Optional<String> next = Optional.ofNullable(connection.getHeaderField("Link"))
+                        .map(nextPagePattern::matcher).filter(Matcher::find).map(matcher -> matcher.group(1));
+
                 try (InputStream is = connection.getInputStream()) {
-                    List<T> list = mapper.readerFor(mapper.getTypeFactory()
-                            .constructCollectionType(List.class, modelClass))
+                    List<T> list = mapper
+                            .readerFor(mapper.getTypeFactory().constructCollectionType(List.class, modelClass))
                             .readValue(is);
+                    if (next.isPresent()) {
+                        list.addAll(getList(next.get(), modelClass));
+                    }
                     // strip null values from the list
-                    for (Iterator<T> iterator = list.iterator(); iterator.hasNext(); ) {
+                    for (Iterator<T> iterator = list.iterator(); iterator.hasNext();) {
                         if (iterator.next() == null) {
                             iterator.remove();
                         }
@@ -986,9 +1003,13 @@ class DefaultGiteaConnection implements GiteaConnection {
         }
     }
 
+    private HttpURLConnection openConnection(UriTemplate template) throws IOException {
+       return openConnection(template.expand());
+    }
+
     @Restricted(NoExternalUse.class)
-    protected HttpURLConnection openConnection(UriTemplate template) throws IOException {
-        URL url = new URL(template.expand());
+    protected HttpURLConnection openConnection(String spec) throws IOException {
+        URL url = new URL(spec);
         Jenkins jenkins = Jenkins.get();
         if (jenkins.proxy == null) {
             return (HttpURLConnection) url.openConnection();

--- a/src/test/java/org/jenkinsci/plugin/gitea/client/impl/GiteaConnection_DisabledPR_Issues.java
+++ b/src/test/java/org/jenkinsci/plugin/gitea/client/impl/GiteaConnection_DisabledPR_Issues.java
@@ -14,6 +14,10 @@ public class GiteaConnection_DisabledPR_Issues extends DefaultGiteaConnection {
     }
 
     @Override
+    protected HttpURLConnection openConnection(String spec) throws IOException {
+        throw new GiteaHttpStatusException(404, "TEST Case");
+    }
+    @Override
     protected HttpURLConnection openConnection(UriTemplate template) throws IOException {
         throw new GiteaHttpStatusException(404, "TEST Case");
     }


### PR DESCRIPTION
use the ref=next link in the response header to support paged requests.

The response header received in getList contains a link to the next page, getList is called recursive with the new URL.

FIX https://issues.jenkins.io/browse/JENKINS-63048