### PR TITLE
Make plugin compatible with Job DSL

### DIFF
--- a/src/main/java/org/jenkinsci/plugin/gitea/ForkPullRequestDiscoveryTrait.java
+++ b/src/main/java/org/jenkinsci/plugin/gitea/ForkPullRequestDiscoveryTrait.java
@@ -42,7 +42,6 @@ import jenkins.scm.api.trait.SCMSourceContext;
 import jenkins.scm.api.trait.SCMSourceRequest;
 import jenkins.scm.api.trait.SCMSourceTrait;
 import jenkins.scm.api.trait.SCMSourceTraitDescriptor;
-import jenkins.scm.api.trait.SCMTrait;
 import jenkins.scm.impl.ChangeRequestSCMHeadCategory;
 import jenkins.scm.impl.trait.Discovery;
 import org.jenkinsci.Symbol;
@@ -78,8 +77,7 @@ public class ForkPullRequestDiscoveryTrait extends SCMSourceTrait {
     @DataBoundConstructor
     @SuppressWarnings({"unchecked", "rawtypes"})
     public ForkPullRequestDiscoveryTrait(int strategyId,
-                                         @NonNull SCMHeadAuthority/*<? super GiteaSCMSourceRequest, ? extends
-                                                  ChangeRequestSCMHead2, ? extends SCMRevision>*/ trust) {
+                                         @NonNull SCMHeadAuthority trust) {
         this.strategyId = strategyId;
         this.trust = trust;
     }

--- a/src/main/java/org/jenkinsci/plugin/gitea/ForkPullRequestDiscoveryTrait.java
+++ b/src/main/java/org/jenkinsci/plugin/gitea/ForkPullRequestDiscoveryTrait.java
@@ -42,6 +42,7 @@ import jenkins.scm.api.trait.SCMSourceContext;
 import jenkins.scm.api.trait.SCMSourceRequest;
 import jenkins.scm.api.trait.SCMSourceTrait;
 import jenkins.scm.api.trait.SCMSourceTraitDescriptor;
+import jenkins.scm.api.trait.SCMTrait;
 import jenkins.scm.impl.ChangeRequestSCMHeadCategory;
 import jenkins.scm.impl.trait.Discovery;
 import org.jenkinsci.Symbol;
@@ -68,13 +69,17 @@ public class ForkPullRequestDiscoveryTrait extends SCMSourceTrait {
     /**
      * Constructor for stapler.
      *
+     * Note: in order to support the JobDSL plugin we cannot use a complex/generic type for the trust parameter.
+     * See: https://issues.jenkins.io/browse/JENKINS-26535
+     *
      * @param strategyId the strategy id.
      * @param trust      the authority to use.
      */
     @DataBoundConstructor
+    @SuppressWarnings({"unchecked", "rawtypes"})
     public ForkPullRequestDiscoveryTrait(int strategyId,
-                                         @NonNull SCMHeadAuthority<? super GiteaSCMSourceRequest, ? extends
-                                                 ChangeRequestSCMHead2, ? extends SCMRevision> trust) {
+                                         @NonNull SCMHeadAuthority/*<? super GiteaSCMSourceRequest, ? extends
+                                                  ChangeRequestSCMHead2, ? extends SCMRevision>*/ trust) {
         this.strategyId = strategyId;
         this.trust = trust;
     }

--- a/src/main/java/org/jenkinsci/plugin/gitea/GiteaSCMNavigator.java
+++ b/src/main/java/org/jenkinsci/plugin/gitea/GiteaSCMNavigator.java
@@ -74,6 +74,7 @@ import jenkins.scm.impl.form.NamedArrayList;
 import jenkins.scm.impl.trait.Discovery;
 import jenkins.scm.impl.trait.Selection;
 import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.Symbol;
 import org.jenkinsci.plugin.gitea.client.api.GiteaAuth;
 import org.jenkinsci.plugin.gitea.client.api.GiteaConnection;
 import org.jenkinsci.plugin.gitea.client.api.Gitea;
@@ -288,6 +289,7 @@ public class GiteaSCMNavigator extends SCMNavigator {
     }
 
     @Extension
+    @Symbol("gitea")
     public static class DescriptorImpl extends SCMNavigatorDescriptor {
 
         @Override

--- a/src/main/java/org/jenkinsci/plugin/gitea/GiteaSCMNavigator.java
+++ b/src/main/java/org/jenkinsci/plugin/gitea/GiteaSCMNavigator.java
@@ -122,10 +122,23 @@ public class GiteaSCMNavigator extends SCMNavigator {
         return Collections.unmodifiableList(traits);
     }
 
-    @Override
+    // we use the simple `SCMTrait[] ` type here instead of List<SCMTrait<? extends SCMTrait<?>>> such that this
+    // property is supported by the Job DSL plugin. See: https://github.com/jenkinsci/bitbucket-branch-source-plugin/pull/278
+    // for a similar fix in the bickbucket plugin repo.
+    @SuppressWarnings({"unchecked", "rawtypes"})
     @DataBoundSetter
-    public void setTraits(List<SCMTrait<? extends SCMTrait<?>>> traits) {
-        this.traits = new ArrayList<>(Util.fixNull(traits));
+    public void setTraits(SCMTrait[]  traits) {
+        this.traits = new ArrayList<>();
+        if (traits != null) {
+            for (SCMTrait trait : traits) {
+                this.traits.add(trait);
+            }
+        }
+    }
+
+    @Override
+    public void setTraits(@CheckForNull List<SCMTrait<? extends SCMTrait<?>>> traits) {
+        this.traits = traits != null ? new ArrayList<>(traits) : new ArrayList<SCMTrait<? extends SCMTrait<?>>>();
     }
 
     @NonNull

--- a/src/main/java/org/jenkinsci/plugin/gitea/OriginPullRequestDiscoveryTrait.java
+++ b/src/main/java/org/jenkinsci/plugin/gitea/OriginPullRequestDiscoveryTrait.java
@@ -124,7 +124,7 @@ public class OriginPullRequestDiscoveryTrait extends SCMSourceTrait {
         return category instanceof ChangeRequestSCMHeadCategory;
     }
 
-    @Symbol("giteaPullREquestDiscovery") // why the gitea prefix? because symbol support doesn't understand types!
+    @Symbol("giteaPullRequestDiscovery") // why the gitea prefix? because symbol support doesn't understand types!
     @Extension
     @Discovery
     public static class DescriptorImpl extends SCMSourceTraitDescriptor {

--- a/src/main/java/org/jenkinsci/plugin/gitea/SSHCheckoutTrait.java
+++ b/src/main/java/org/jenkinsci/plugin/gitea/SSHCheckoutTrait.java
@@ -49,6 +49,7 @@ import jenkins.scm.api.trait.SCMSourceContext;
 import jenkins.scm.api.trait.SCMSourceTrait;
 import jenkins.scm.api.trait.SCMSourceTraitDescriptor;
 import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.Symbol;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.AncestorInPath;
@@ -76,6 +77,7 @@ public class SSHCheckoutTrait extends SCMSourceTrait {
     }
 
     @Extension
+    @Symbol("giteaSSHCheckout")
     public static class DescriptorImpl extends SCMSourceTraitDescriptor {
 
         @NonNull

--- a/src/main/java/org/jenkinsci/plugin/gitea/TagDiscoveryTrait.java
+++ b/src/main/java/org/jenkinsci/plugin/gitea/TagDiscoveryTrait.java
@@ -40,6 +40,7 @@ import jenkins.scm.api.trait.SCMSourceTrait;
 import jenkins.scm.api.trait.SCMSourceTraitDescriptor;
 import jenkins.scm.impl.TagSCMHeadCategory;
 import jenkins.scm.impl.trait.Discovery;
+import org.jenkinsci.Symbol;
 import org.jenkinsci.plugin.gitea.client.api.GiteaPullRequest;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
@@ -79,6 +80,7 @@ public class TagDiscoveryTrait extends SCMSourceTrait {
      */
     @Extension
     @Discovery
+    @Symbol("giteaTagDiscovery")
     public static class DescriptorImpl extends SCMSourceTraitDescriptor {
 
         /**

--- a/src/main/java/org/jenkinsci/plugin/gitea/WebhookRegistrationTrait.java
+++ b/src/main/java/org/jenkinsci/plugin/gitea/WebhookRegistrationTrait.java
@@ -30,6 +30,7 @@ import jenkins.scm.api.SCMSource;
 import jenkins.scm.api.trait.SCMSourceContext;
 import jenkins.scm.api.trait.SCMSourceTrait;
 import jenkins.scm.api.trait.SCMSourceTraitDescriptor;
+import org.jenkinsci.Symbol;
 import org.jenkinsci.plugin.gitea.servers.GiteaServers;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
@@ -88,6 +89,7 @@ public class WebhookRegistrationTrait extends SCMSourceTrait {
      * Our constructor.
      */
     @Extension
+    @Symbol("giteaWebhookRegistration")
     public static class DescriptorImpl extends SCMSourceTraitDescriptor {
 
         /**


### PR DESCRIPTION
Hi 

First of all, a big thanks for picking up maintenance for this plugin again!

We are using this plugin with an initial root job using the job DSL. The current version of the plugin has two problems regarding DSL support:

- it is impossible to configure the `traits` of `giteaSCMNavigator`
- it is impossible to configure the `giteaForkDiscovery` trait

This PR adds full support for configuration via the Job DSL plugin.

Fixes:

- https://issues.jenkins.io/browse/JENKINS-66584
- https://issues.jenkins.io/browse/JENKINS-64580