### PR TITLE
Fix release versioning + incremental builds

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -53,3 +53,14 @@ jobs:
         MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
         MAVEN_TOKEN: ${{ secrets.MAVEN_TOKEN }}
         NO_CHANGELIST: '1'
+    - name: Setup Git user
+      run: |
+        git config --local user.name "github-actions[bot]"
+        git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+    - name: Lock auto-incremented version
+      run: |
+        mvn -B -ntp -DgenerateBackupPoms=false -Drevision=$(mvn -B -ntp -Dchangelist= -Dexpression=project.version -q -DforceStdout help:evaluate) release:update-versions
+        mvn -B -ntp -Dignore.dirt incrementals:reincrementalify
+        git add pom.xml
+        git commit -m "[github-action] prepare for next development iteration"
+        git push

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -47,8 +47,9 @@ jobs:
         distribution: 'adopt'
         java-version: 8
     - name: Release
-      uses: jenkins-infra/jenkins-maven-cd-action@v1.2.0
+      uses: justusbunsi/jenkins-maven-cd-action@v1.2.1
       with:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
         MAVEN_TOKEN: ${{ secrets.MAVEN_TOKEN }}
+        NO_CHANGELIST: '1'

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Gitea Plugin
 
-[![](https://img.shields.io/jenkins/plugin/v/gitea.svg?label=version)](https://plugins.jenkins.io/gitea)
-[![](https://img.shields.io/github/v/release/jenkinsci/gitea-plugin.svg?label=changelog)](https://github.com/jenkinsci/gitea-plugin/releases/latest)
-[![](https://img.shields.io/jenkins/plugin/i/gitea.svg?color=blue)](https://plugins.jenkins.io/gitea)
+[![Version](https://img.shields.io/jenkins/plugin/v/gitea.svg?label=version)](https://plugins.jenkins.io/gitea)
+[![Changelog](https://img.shields.io/github/v/release/jenkinsci/gitea-plugin.svg?label=changelog)](https://github.com/jenkinsci/gitea-plugin/releases/latest)
+[![Installs](https://img.shields.io/jenkins/plugin/i/gitea.svg?color=blue)](https://plugins.jenkins.io/gitea)
 
 This plugin provides the Jenkins integrations for [Gitea](https://gitea.io).
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>gitea</artifactId>
-    <version>${revision}</version>
+    <version>${revision}${changelist}</version>
     <packaging>hpi</packaging>
 
     <name>Gitea Plugin</name>
@@ -32,7 +32,7 @@
 
     <properties>
         <revision>1.4.1</revision>
-        <changelist>999999-SNAPSHOT</changelist>
+        <changelist>-SNAPSHOT</changelist>
         <java.level>8</java.level>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     </scm>
 
     <properties>
-        <revision>1.5.0</revision>
+        <revision>1.4.1</revision>
         <changelist>999999-SNAPSHOT</changelist>
         <java.level>8</java.level>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
The last Pull Request broke the incremental builds whilst trying to fix the release tagging/deploy syntax.

The used workflow to deploy the artifact and create a tag + release on GitHub does not support a clean version such as `1.4.0` instead of `1.4.0-rc....`. This is due to the hardcoded `-Dset.changelist` flag which does not allow skipping the suffix.

As the Gitea plugin should have clean release names, I switched to my fork where this feature is implemented. We can use it as long as the [upstream PR for that workflow](https://github.com/jenkins-infra/jenkins-maven-cd-action/pull/13) is not merged.

In addition to that, I've came to the conclusion that it wouldn't be wise to not skip all the interim versions between 1.4.0 and 1.5.0. Why should we do this. So back to 1.4.1. 😄

We now have a fully automated release on button click (workflow_dispatch). After releasing the current version, the workflow also bumps the incremental/patch version to the next higher version. If there is a need to increase the minor version, we'd need to do it manually.

The only thing I couldn't get working is the `gitea-` prefix for tags and the `v` prefix on release subjects. But I think the current way is totally fine.