### PR TITLE
[JENKINS-67068] Fix regression for branch names with slashes

### DIFF
--- a/src/main/java/org/jenkinsci/plugin/gitea/client/impl/DefaultGiteaConnection.java
+++ b/src/main/java/org/jenkinsci/plugin/gitea/client/impl/DefaultGiteaConnection.java
@@ -270,11 +270,11 @@ class DefaultGiteaConnection implements GiteaConnection {
                         .path(UriTemplateBuilder.var("username"))
                         .path(UriTemplateBuilder.var("repository"))
                         .literal("/branches")
-                        .path(UriTemplateBuilder.var("name"))
+                        .path(UriTemplateBuilder.var("name", true))
                         .build()
                         .set("username", username)
                         .set("repository", repository)
-                        .set("name", name),
+                        .set("name", StringUtils.split(name, '/')),
                 GiteaBranch.class
         );
     }


### PR DESCRIPTION
As a result of PR #29 it happens that some users cannot fetch branches
with slashes in their names anymore.

Looks like it's an issue with manually triggering jobs.

Regression from: [JENKINS-65796](https://issues.jenkins.io/browse/JENKINS-65796)

Fixes: [JENKINS-67068](https://issues.jenkins.io/browse/JENKINS-67068)
