### PR TITLE
Provide dedicated symbol for personal access token

### DIFF
--- a/src/main/java/org/jenkinsci/plugin/gitea/credentials/PersonalAccessTokenImpl.java
+++ b/src/main/java/org/jenkinsci/plugin/gitea/credentials/PersonalAccessTokenImpl.java
@@ -34,6 +34,7 @@ import hudson.util.FormValidation;
 import hudson.util.Secret;
 import jenkins.model.Jenkins;
 import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.Symbol;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -77,6 +78,7 @@ public class PersonalAccessTokenImpl extends BaseStandardCredentials implements 
     /**
      * Our descriptor.
      */
+    @Symbol("giteaAccessToken")
     @Extension
     public static class DescriptorImpl extends CredentialsDescriptor {
         /**


### PR DESCRIPTION
Right now, one has to use `personalAccessTokenImpl` to define a Jenkins
credential for Gitea token.

This adds the Symbol `giteaAccessToken` so that it is possible to
identify their relation with the Gitea plugin in Configuration as Code
snippets.

It is still possible to use the old one.

```diff
 credentials:
   system:
     domainCredentials:
     - credentials:
-      - personalAccessTokenImpl:
+      - giteaAccessToken:
           id: gitea-token
           scope: GLOBAL
           token: "personal-gitea-token-placeholder"
```