### PR TITLE
Switch to PR creation for version bump

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -63,4 +63,11 @@ jobs:
         mvn -B -ntp -Dignore.dirt incrementals:reincrementalify
         git add pom.xml
         git commit -m "[github-action] prepare for next development iteration"
-        git push
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v3
+      with:
+        title: '[github-action] Bump version'
+        body: ""
+        labels: "skip-changelog"
+        signoff: false
+        delete-branch: true


### PR DESCRIPTION
The recent release 1.4.1 showed that pushing to the default branch within a GitHub workflow is not possible with our current branch protection. As an alternative way to automate the version bump, a PR is created which won't show up in future releases (due to its label).