### PR TITLE
fix JENKINS-68435: Revert "Remove useless code for building clone url…

### DIFF
--- a/src/main/java/org/jenkinsci/plugin/gitea/GiteaSCMBuilder.java
+++ b/src/main/java/org/jenkinsci/plugin/gitea/GiteaSCMBuilder.java
@@ -37,6 +37,7 @@ import hudson.model.Queue;
 import hudson.plugins.git.GitSCM;
 import hudson.security.ACL;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
@@ -48,6 +49,7 @@ import jenkins.scm.api.SCMSourceOwner;
 import jenkins.scm.api.mixin.ChangeRequestCheckoutStrategy;
 import org.eclipse.jgit.lib.Constants;
 import org.eclipse.jgit.transport.RefSpec;
+import org.jenkinsci.plugin.gitea.credentials.PersonalAccessToken;
 
 /**
  * Builds a {@link GitSCM} for {@link GiteaSCMSource}.
@@ -170,6 +172,27 @@ public class GiteaSCMBuilder extends GitSCMBuilder<GiteaSCMBuilder> {
                         .path(UriTemplateBuilder.var("repository"))
                         .literal(".git")
                         .build();
+            }
+            if (credentials instanceof PersonalAccessToken) {
+                try {
+                    // TODO is there a way we can get git plugin to redact the secret?
+                    URI tokenUri = new URI(
+                            serverUri.getScheme(),
+                            ((PersonalAccessToken) credentials).getToken().getPlainText(),
+                            serverUri.getHost(),
+                            serverUri.getPort(),
+                            serverUri.getPath(),
+                            serverUri.getQuery(),
+                            serverUri.getFragment()
+                    );
+                    return UriTemplate.buildFromTemplate(tokenUri.toASCIIString())
+                            .path(UriTemplateBuilder.var("owner"))
+                            .path(UriTemplateBuilder.var("repository"))
+                            .literal(".git")
+                            .build();
+                } catch (URISyntaxException e) {
+                    // ok we are at the end of the road
+                }
             }
         }
         return UriTemplate.buildFromTemplate(serverUrl)


### PR DESCRIPTION
Tackling the issue  [JENKINS-68435](https://issues.jenkins.io/browse/JENKINS-68435)

This reverts commit 88a1ac7193658da64db9f452916a8b93de0aa648. (introduced in #50 )

* It seems the code dropps the whole credential provider, and falls back to User:Password / SSH

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
