### PR TITLE
Use username from sshkey credentials instead of "git" when checking out with ssh://

### DIFF
--- a/src/main/java/org/jenkinsci/plugin/gitea/BranchDiscoveryTrait.java
+++ b/src/main/java/org/jenkinsci/plugin/gitea/BranchDiscoveryTrait.java
@@ -68,11 +68,12 @@ public class BranchDiscoveryTrait extends SCMSourceTrait {
     /**
      * Constructor for legacy code.
      *
-     * @param buildBranch       build branches that are not filed as a PR.
-     * @param buildBranchWithPr build branches that are also PRs.
+     * @param buildBranch               build branches that are not filed as a PR.
+     * @param buildBranchWithPr         build branches that are also PRs.
+     * @param buildBranchWithPrOrMaster build branches that are also PRs or that are master.
      */
-    public BranchDiscoveryTrait(boolean buildBranch, boolean buildBranchWithPr) {
-        this.strategyId = (buildBranch ? 1 : 0) + (buildBranchWithPr ? 2 : 0);
+    public BranchDiscoveryTrait(boolean buildBranch, boolean buildBranchWithPr, boolean buildBranchWithPrOrMaster) {
+        this.strategyId = (buildBranch ? 1 : 0) + (buildBranchWithPr ? 2 : 0) +  (buildBranchWithPr ? 4 : 0);
     }
 
     /**
@@ -106,6 +107,16 @@ public class BranchDiscoveryTrait extends SCMSourceTrait {
     }
 
     /**
+     * Returns {@code true} if building branches that are filed as a PR or the master branch.
+     *
+     * @return {@code true} if building branches that are filed as a PR or the master branch.
+     */
+    @Restricted(NoExternalUse.class)
+    public boolean isBuildBranchesWithPROrMaster() {
+        return (strategyId & 4) != 0;
+    }
+
+    /**
      * {@inheritDoc}
      */
     @Override
@@ -121,6 +132,10 @@ public class BranchDiscoveryTrait extends SCMSourceTrait {
             case 2:
                 ctx.wantOriginPRs(true);
                 ctx.withFilter(new OnlyOriginPRBranchesSCMHeadFilter());
+                break;
+            case 4:
+                ctx.wantOriginPRs(true);
+                ctx.withFilter(new OriginPRBranchesOrMasterSCMHeadFilter());
                 break;
             case 3:
             default:
@@ -183,6 +198,7 @@ public class BranchDiscoveryTrait extends SCMSourceTrait {
             result.add(Messages.BranchDiscoveryTrait_excludePRs(), "1");
             result.add(Messages.BranchDiscoveryTrait_onlyPRs(), "2");
             result.add(Messages.BranchDiscoveryTrait_allBranches(), "3");
+            result.add(Messages.BranchDiscoveryTrait_onlyPRsOrMaster(), "4");
             return result;
         }
     }
@@ -270,6 +286,45 @@ public class BranchDiscoveryTrait extends SCMSourceTrait {
         @Override
         public boolean isExcluded(@NonNull SCMSourceRequest request, @NonNull SCMHead head) {
             if (head instanceof BranchSCMHead && request instanceof GiteaSCMSourceRequest) {
+                for (GiteaPullRequest p : ((GiteaSCMSourceRequest) request).getPullRequests()) {
+                    if (p.getHead() == null || p.getHead().getRepo() == null
+                            || p.getHead().getRepo().getOwner() == null
+                            || p.getHead().getRepo().getName() == null
+                            || p.getHead().getRef() == null
+                    ) {
+                        // the head has already been deleted, so ignore as we cannot build yet JENKINS-60825
+                        // TODO figure out if we can build a PR who's head has been deleted as it should be possible
+                        return true;
+                    }
+                    if (StringUtils.equalsIgnoreCase(
+                            p.getBase().getRepo().getOwner().getUsername(),
+                            p.getHead().getRepo().getOwner().getUsername())
+                            && StringUtils.equalsIgnoreCase(
+                                    p.getBase().getRepo().getName(),
+                            p.getHead().getRepo().getName())
+                            && StringUtils.equals(p.getHead().getRef(), head.getName())) {
+                        return false;
+                    }
+                }
+                return true;
+            }
+            return false;
+        }
+    }
+
+    /**
+     * Filter that excludes branches that are not also filed as a pull request.
+     */
+    public static class OriginPRBranchesOrMasterSCMHeadFilter extends SCMHeadFilter {
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public boolean isExcluded(@NonNull SCMSourceRequest request, @NonNull SCMHead head) {
+            if (head instanceof BranchSCMHead && request instanceof GiteaSCMSourceRequest) {
+                if (head.getName().equalsIgnoreCase( "master") || head.getName().equalsIgnoreCase("main")) {
+                    return false;
+                }
                 for (GiteaPullRequest p : ((GiteaSCMSourceRequest) request).getPullRequests()) {
                     if (p.getHead() == null || p.getHead().getRepo() == null
                             || p.getHead().getRepo().getOwner() == null

--- a/src/main/java/org/jenkinsci/plugin/gitea/GiteaSCMBuilder.java
+++ b/src/main/java/org/jenkinsci/plugin/gitea/GiteaSCMBuilder.java
@@ -158,7 +158,7 @@ public class GiteaSCMBuilder extends GitSCMBuilder<GiteaSCMBuilder> {
                 int colonIndex = sshRemote.indexOf(':');
                 if (atIndex != -1 && colonIndex != -1 && atIndex < colonIndex) {
                     // this is an scp style url, we will translate to ssh style
-                    return UriTemplate.buildFromTemplate("ssh://"+sshRemote.substring(0, colonIndex))
+                    return UriTemplate.buildFromTemplate("ssh://" + sshRemote.substring(0, colonIndex))
                             .path(UriTemplateBuilder.var("owner"))
                             .path(UriTemplateBuilder.var("repository"))
                             .literal(".git")
@@ -166,8 +166,8 @@ public class GiteaSCMBuilder extends GitSCMBuilder<GiteaSCMBuilder> {
                 }
                 URI sshUri = URI.create(sshRemote);
                 return UriTemplate.buildFromTemplate(
-                        "ssh://git@" + sshUri.getHost() + (sshUri.getPort() != 22 && sshUri.getPort() != -1 ? ":" + sshUri.getPort() : "")
-                )
+                                "ssh://" + ((SSHUserPrivateKey) credentials).getUsername() + "@" + sshUri.getHost() + (sshUri.getPort() != 22 && sshUri.getPort() != -1 ? ":" + sshUri.getPort() : "")
+                        )
                         .path(UriTemplateBuilder.var("owner"))
                         .path(UriTemplateBuilder.var("repository"))
                         .literal(".git")

--- a/src/main/java/org/jenkinsci/plugin/gitea/GiteaSCMSource.java
+++ b/src/main/java/org/jenkinsci/plugin/gitea/GiteaSCMSource.java
@@ -955,7 +955,7 @@ public class GiteaSCMSource extends AbstractGitSCMSource {
 
         public List<SCMSourceTrait> getTraitsDefaults() {
             return Arrays.asList( // TODO finalize
-                    new BranchDiscoveryTrait(true, false),
+                    new BranchDiscoveryTrait(true, false, false),
                     new OriginPullRequestDiscoveryTrait(EnumSet.of(ChangeRequestCheckoutStrategy.MERGE)),
                     new ForkPullRequestDiscoveryTrait(EnumSet.of(ChangeRequestCheckoutStrategy.MERGE),
                             new ForkPullRequestDiscoveryTrait.TrustContributors())

--- a/src/main/resources/org/jenkinsci/plugin/gitea/BranchDiscoveryTrait/help-strategyId.html
+++ b/src/main/resources/org/jenkinsci/plugin/gitea/BranchDiscoveryTrait/help-strategyId.html
@@ -11,6 +11,10 @@
             This option exists to preserve legacy behaviour when upgrading from older versions of the plugin.
             NOTE: If you have an actual use case for this option please file a pull request against this text.
         </dd>
+        <dt>Only branches that are also filed as PRs or master</dt>
+        <dd>
+            PRs or master
+        </dd>
         <dt>All branches</dt>
         <dd>
             Ignores whether the branch is also filed as a pull request and instead discovers all branches on the

--- a/src/main/resources/org/jenkinsci/plugin/gitea/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugin/gitea/Messages.properties
@@ -3,6 +3,7 @@ BranchDiscoveryTrait.authorityDisplayName=Trust origin branches
 BranchDiscoveryTrait.displayName=Discover branches
 BranchDiscoveryTrait.excludePRs=Only branches that are not also filed as PRs
 BranchDiscoveryTrait.onlyPRs=Only branches that are also filed as PRs
+BranchDiscoveryTrait.onlyPRsOrMaster=Only branches that are also filed as PRs or master branch
 ForkPullRequestDiscoveryTrait.contributorsDisplayName=Contributors
 ForkPullRequestDiscoveryTrait.displayName=Discover pull requests from forks
 ForkPullRequestDiscoveryTrait.everyoneDisplayName=Everyone


### PR DESCRIPTION
When you use a sshkey for authentication, it will always use the user "git" if you choose ssh:// (instead of https://).
This pr changes this: It will use the username from the sshkey credentials.

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue