### PR TITLE
Use username from sshkey credentials instead of "git" when checking out with ssh://

### DIFF
--- a/src/main/java/org/jenkinsci/plugin/gitea/GiteaSCMBuilder.java
+++ b/src/main/java/org/jenkinsci/plugin/gitea/GiteaSCMBuilder.java
@@ -158,7 +158,7 @@ public class GiteaSCMBuilder extends GitSCMBuilder<GiteaSCMBuilder> {
                 int colonIndex = sshRemote.indexOf(':');
                 if (atIndex != -1 && colonIndex != -1 && atIndex < colonIndex) {
                     // this is an scp style url, we will translate to ssh style
-                    return UriTemplate.buildFromTemplate("ssh://"+sshRemote.substring(0, colonIndex))
+                    return UriTemplate.buildFromTemplate("ssh://" + sshRemote.substring(0, colonIndex))
                             .path(UriTemplateBuilder.var("owner"))
                             .path(UriTemplateBuilder.var("repository"))
                             .literal(".git")
@@ -166,8 +166,8 @@ public class GiteaSCMBuilder extends GitSCMBuilder<GiteaSCMBuilder> {
                 }
                 URI sshUri = URI.create(sshRemote);
                 return UriTemplate.buildFromTemplate(
-                        "ssh://git@" + sshUri.getHost() + (sshUri.getPort() != 22 && sshUri.getPort() != -1 ? ":" + sshUri.getPort() : "")
-                )
+                                "ssh://" + ((SSHUserPrivateKey) credentials).getUsername() + "@" + sshUri.getHost() + (sshUri.getPort() != 22 && sshUri.getPort() != -1 ? ":" + sshUri.getPort() : "")
+                        )
                         .path(UriTemplateBuilder.var("owner"))
                         .path(UriTemplateBuilder.var("repository"))
                         .literal(".git")


### PR DESCRIPTION
When you use a sshkey for authentication, it will always use the user "git" if you choose ssh:// (instead of https://).
This pr changes this: It will use the username from the sshkey credentials.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue