### PR TITLE
Add gitea release handling

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,6 @@
     "cSpell.words": [
         "gitea",
         "repos"
-    ]
+    ],
+    "java.configuration.updateBuildConfiguration": "interactive"
 }

--- a/pom.xml
+++ b/pom.xml
@@ -104,11 +104,6 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
-        <!--<dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>branch-api</artifactId>
-            <scope>test</scope>
-        </dependency>-->
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-multibranch</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,10 @@
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>branch-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>git</artifactId>
         </dependency>
         <dependency>
@@ -100,11 +104,11 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
+        <!--<dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>branch-api</artifactId>
             <scope>test</scope>
-        </dependency>
+        </dependency>-->
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-multibranch</artifactId>

--- a/src/main/java/org/jenkinsci/plugin/gitea/GiteaNotifier.java
+++ b/src/main/java/org/jenkinsci/plugin/gitea/GiteaNotifier.java
@@ -132,6 +132,11 @@ public class GiteaNotifier {
                     status.getState().name(), status.getDescription());
             hash = ((TagSCMRevision) revision).getHash();
             statusContext += "tag";
+        } else if (revision instanceof ReleaseSCMRevision) {
+            listener.getLogger().format("[Gitea] Notifying release build status: %s %s%n",
+                    status.getState().name(), status.getDescription());
+            hash = ((ReleaseSCMRevision) revision).getHash();
+            statusContext += "release";
         } else {
             return;
         }
@@ -237,6 +242,10 @@ public class GiteaNotifier {
                             LOGGER.log(Level.INFO, "Notifying tag pending build {0}", job.getFullName());
                             statusContext += "tag";
                             hash = ((TagSCMRevision) revision).getHash();
+                        } else if (revision instanceof ReleaseSCMRevision) {
+                            LOGGER.log(Level.INFO, "Notifying release pending build {0}", job.getFullName());
+                            statusContext += "release";
+                            hash = ((ReleaseSCMRevision) revision).getHash();
                         } else {
                             return;
                         }

--- a/src/main/java/org/jenkinsci/plugin/gitea/GiteaReleaseNotifier.java
+++ b/src/main/java/org/jenkinsci/plugin/gitea/GiteaReleaseNotifier.java
@@ -1,0 +1,93 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017-2022, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugin.gitea;
+
+import java.io.IOException;
+
+import org.jenkinsci.plugin.gitea.client.api.GiteaConnection;
+import org.jenkinsci.plugin.gitea.client.api.GiteaRepository;
+
+import hudson.Extension;
+import hudson.model.Result;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.model.listeners.RunListener;
+import jenkins.scm.api.SCMHead;
+import jenkins.scm.api.SCMHeadObserver;
+import jenkins.scm.api.SCMSource;
+import jenkins.util.VirtualFile;
+
+public class GiteaReleaseNotifier {
+
+    public static void publishArtifacts(Run<?, ?> build, TaskListener listener)
+            throws IOException, InterruptedException {
+
+        if (build.getResult() != Result.SUCCESS) {
+            // do not push assets when the pipeline wasn't a success
+            listener.getLogger().format("[Gitea] do not publish assets due to build being non-Successfully%n");
+            return;
+        }
+
+        final SCMSource s = SCMSource.SourceByItem.findSource(build.getParent());
+        if (!(s instanceof GiteaSCMSource)) {
+            listener.getLogger().format("[Gitea] do not publish assets due to source being no GiteaSCMSource%n");
+            return;
+        }
+        final GiteaSCMSource source = (GiteaSCMSource) s;
+        if (!new GiteaSCMSourceContext(null, SCMHeadObserver.none())
+                .withTraits(source.getTraits())
+                .artifactToAssetMappingEnabled()) {
+            return;
+        }
+        final SCMHead head = SCMHead.HeadByItem.findHead(build.getParent());
+        if (head == null || !(head instanceof ReleaseSCMHead)) {
+            listener.getLogger().format("[Gitea] do not publish assets due to head either being null or no ReleaseSCMHead%n");
+            return;
+        }
+
+        try (GiteaConnection c = source.gitea().open()) {
+            GiteaRepository repository = c.fetchRepository(source.getRepoOwner(), source.getRepository());
+            long releaseId = ((ReleaseSCMHead) head).getId();
+
+            for (Run<?, ?>.Artifact artifact : build.getArtifacts()) {
+                VirtualFile file = build.getArtifactManager().root().child(artifact.relativePath);
+                c.createReleaseAttachment(repository, releaseId, artifact.getFileName(), file.open());
+                listener.getLogger().format("[Gitea] Published asset from archived artifact %s%n", artifact.getFileName());
+            }
+        }
+    }
+
+    @Extension
+    public static class JobCompletedListener extends RunListener<Run<?, ?>> {
+
+        @Override
+        public void onCompleted(Run<?, ?> build, TaskListener listener) {
+            try {
+                publishArtifacts(build, listener);
+            } catch (IOException | InterruptedException e) {
+                e.printStackTrace(listener.error("Could not upload assets for release"));
+            }
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/plugin/gitea/GiteaReleaseNotifier.java
+++ b/src/main/java/org/jenkinsci/plugin/gitea/GiteaReleaseNotifier.java
@@ -23,20 +23,18 @@
  */
 package org.jenkinsci.plugin.gitea;
 
-import java.io.IOException;
-
-import org.jenkinsci.plugin.gitea.client.api.GiteaConnection;
-import org.jenkinsci.plugin.gitea.client.api.GiteaRepository;
-
 import hudson.Extension;
 import hudson.model.Result;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.model.listeners.RunListener;
+import java.io.IOException;
 import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMHeadObserver;
 import jenkins.scm.api.SCMSource;
 import jenkins.util.VirtualFile;
+import org.jenkinsci.plugin.gitea.client.api.GiteaConnection;
+import org.jenkinsci.plugin.gitea.client.api.GiteaRepository;
 
 public class GiteaReleaseNotifier {
 

--- a/src/main/java/org/jenkinsci/plugin/gitea/GiteaReleaseSCMEvent.java
+++ b/src/main/java/org/jenkinsci/plugin/gitea/GiteaReleaseSCMEvent.java
@@ -1,0 +1,74 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017-2022, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugin.gitea;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+
+import org.jenkinsci.plugin.gitea.client.api.GiteaConnection;
+import org.jenkinsci.plugin.gitea.client.api.GiteaReleaseEvent;
+import org.jenkinsci.plugin.gitea.client.api.GiteaTag;
+
+import hudson.Extension;
+import jenkins.scm.api.SCMHead;
+import jenkins.scm.api.SCMHeadEvent;
+import jenkins.scm.api.SCMRevision;
+
+public class GiteaReleaseSCMEvent extends AbstractGiteaSCMHeadEvent<GiteaReleaseEvent> {
+
+    public GiteaReleaseSCMEvent(GiteaReleaseEvent payload, String origin) {
+        super(Type.CREATED, payload, origin);
+    }
+
+    @Override
+    protected Map<SCMHead, SCMRevision> headsFor(GiteaSCMSource source) {
+        String ref = getPayload().getRelease().getTagName();
+        String sha = null;
+
+        try (GiteaConnection c = source.gitea().open()) {
+            GiteaTag releaseTag = c.fetchTag(source.getRepoOwner(), source.getRepository(), ref);
+            sha = releaseTag.getCommit().getSha();
+        } catch (IOException | InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+
+        ReleaseSCMHead h = new ReleaseSCMHead(ref, getPayload().getRelease().getId());
+        return Collections.<SCMHead, SCMRevision>singletonMap(h, new ReleaseSCMRevision(h, sha));
+    }
+
+    @Extension
+    public static class HandlerImpl extends GiteaWebhookHandler<GiteaReleaseSCMEvent, GiteaReleaseEvent> {
+
+        @Override
+        protected GiteaReleaseSCMEvent createEvent(GiteaReleaseEvent payload, String origin) {
+            return new GiteaReleaseSCMEvent(payload, origin);
+        }
+
+        @Override
+        protected void process(GiteaReleaseSCMEvent event) {
+            SCMHeadEvent.fireNow(event);
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/plugin/gitea/GiteaReleaseSCMEvent.java
+++ b/src/main/java/org/jenkinsci/plugin/gitea/GiteaReleaseSCMEvent.java
@@ -23,18 +23,16 @@
  */
 package org.jenkinsci.plugin.gitea;
 
+import hudson.Extension;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
-
-import org.jenkinsci.plugin.gitea.client.api.GiteaConnection;
-import org.jenkinsci.plugin.gitea.client.api.GiteaReleaseEvent;
-import org.jenkinsci.plugin.gitea.client.api.GiteaTag;
-
-import hudson.Extension;
 import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMHeadEvent;
 import jenkins.scm.api.SCMRevision;
+import org.jenkinsci.plugin.gitea.client.api.GiteaConnection;
+import org.jenkinsci.plugin.gitea.client.api.GiteaReleaseEvent;
+import org.jenkinsci.plugin.gitea.client.api.GiteaTag;
 
 public class GiteaReleaseSCMEvent extends AbstractGiteaSCMHeadEvent<GiteaReleaseEvent> {
 

--- a/src/main/java/org/jenkinsci/plugin/gitea/GiteaReleaseSCMEvent.java
+++ b/src/main/java/org/jenkinsci/plugin/gitea/GiteaReleaseSCMEvent.java
@@ -29,7 +29,6 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
 import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMHeadEvent;
 import jenkins.scm.api.SCMRevision;

--- a/src/main/java/org/jenkinsci/plugin/gitea/GiteaReleaseSCMEvent.java
+++ b/src/main/java/org/jenkinsci/plugin/gitea/GiteaReleaseSCMEvent.java
@@ -27,7 +27,6 @@ import hudson.Extension;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMHeadEvent;

--- a/src/main/java/org/jenkinsci/plugin/gitea/GiteaSCMBuilder.java
+++ b/src/main/java/org/jenkinsci/plugin/gitea/GiteaSCMBuilder.java
@@ -109,6 +109,9 @@ public class GiteaSCMBuilder extends GitSCMBuilder<GiteaSCMBuilder> {
         } else if (head instanceof TagSCMHead) {
             withRefSpec("+refs/tags/" + head.getName() + ":refs/tags/@{remote}/" + head.getName());
             repoUrl = repositoryUrl(repoOwner, repository);
+        } else if (head instanceof ReleaseSCMHead) {
+            withRefSpec("+refs/tags/" + head.getName() + ":refs/tags/@{remote}/" + head.getName());
+            repoUrl = repositoryUrl(repoOwner, repository);
         } else {
             withRefSpec("+refs/heads/" + head.getName() + ":refs/remotes/@{remote}/" + head.getName());
             repoUrl = repositoryUrl(repoOwner, repository);

--- a/src/main/java/org/jenkinsci/plugin/gitea/GiteaSCMFileSystem.java
+++ b/src/main/java/org/jenkinsci/plugin/gitea/GiteaSCMFileSystem.java
@@ -68,6 +68,8 @@ public class GiteaSCMFileSystem extends SCMFileSystem {
                 this.ref = ((BranchSCMRevision) rev).getHash();
             } else if (rev instanceof TagSCMRevision) {
                 this.ref = ((TagSCMRevision) rev).getHash();
+            } else if (rev instanceof ReleaseSCMRevision) {
+                this.ref = ((ReleaseSCMRevision) rev).getHash();
             } else {
                 this.ref = ref;
             }
@@ -139,6 +141,10 @@ public class GiteaSCMFileSystem extends SCMFileSystem {
                 repository = src.getRepository();
                 ref = head.getName();
             } else if (head instanceof TagSCMHead) {
+                repoOwner = src.getRepoOwner();
+                repository = src.getRepository();
+                ref = head.getName();
+            } else if (head instanceof ReleaseSCMHead) {
                 repoOwner = src.getRepoOwner();
                 repository = src.getRepository();
                 ref = head.getName();

--- a/src/main/java/org/jenkinsci/plugin/gitea/GiteaSCMNavigator.java
+++ b/src/main/java/org/jenkinsci/plugin/gitea/GiteaSCMNavigator.java
@@ -91,7 +91,7 @@ public class GiteaSCMNavigator extends SCMNavigator {
     private final String serverUrl;
     private final String repoOwner;
     private String credentialsId;
-    private List<SCMTrait<?>> traits = new ArrayList<>();
+    private List<SCMTrait<? extends SCMTrait<?>>> traits = new ArrayList<>();
     private GiteaOwner giteaOwner;
 
     @DataBoundConstructor
@@ -118,7 +118,7 @@ public class GiteaSCMNavigator extends SCMNavigator {
     }
 
     @NonNull
-    public List<SCMTrait<?>> getTraits() {
+    public List<SCMTrait<? extends SCMTrait<?>>> getTraits() {
         return Collections.unmodifiableList(traits);
     }
 

--- a/src/main/java/org/jenkinsci/plugin/gitea/GiteaSCMSource.java
+++ b/src/main/java/org/jenkinsci/plugin/gitea/GiteaSCMSource.java
@@ -263,9 +263,10 @@ public class GiteaSCMSource extends AbstractGitSCMSource {
                     return null;
                 }
             } else if (head instanceof ReleaseSCMHead) {
-                // TODO: this need consideration if we want to implement "changing" releases and how assets shouls be handled then
-                listener.getLogger().format("Tag for release cannot change, we assume that the tag therefore also shouldn't change...%n");
-                return null;
+                ReleaseSCMHead h = (ReleaseSCMHead) head;
+                final GiteaTag tag = c.fetchTag(repoOwner, repository, h.getName());
+                String revision = tag.getCommit().getSha();
+                return new ReleaseSCMRevision(new ReleaseSCMHead(h.getName(), h.getId()), revision);
             } else {
                 listener.getLogger().format("Unknown head: %s of type %s%n", head.getName(), head.getClass().getName());
                 return null;

--- a/src/main/java/org/jenkinsci/plugin/gitea/GiteaSCMSource.java
+++ b/src/main/java/org/jenkinsci/plugin/gitea/GiteaSCMSource.java
@@ -313,8 +313,7 @@ public class GiteaSCMSource extends AbstractGitSCMSource {
                     }
                 }
                 if (request.isFetchReleases()) {
-                    request.setReleases(c.fetchReleases(giteaRepository,
-                        request.isIncludingDraftReleases(), request.isIncludingPreReleases()));
+                    request.setReleases(c.fetchReleases(giteaRepository, false, request.isIncludingPreReleases()));
                 }
 
                 if (request.isFetchBranches()) {

--- a/src/main/java/org/jenkinsci/plugin/gitea/GiteaSCMSourceContext.java
+++ b/src/main/java/org/jenkinsci/plugin/gitea/GiteaSCMSourceContext.java
@@ -39,7 +39,6 @@ public class GiteaSCMSourceContext
     private boolean wantBranches;
     private boolean wantTags;
     private boolean wantReleases;
-    private boolean includesDraftReleases;
     private boolean includesPreReleases;
     private boolean wantOriginPRs;
     private boolean wantForkPRs;
@@ -66,10 +65,6 @@ public class GiteaSCMSourceContext
 
     public final boolean wantReleases() {
         return wantReleases;
-    }
-
-    public final boolean includesDraftReleases() {
-        return includesDraftReleases;
     }
 
     public final boolean includesPreReleases() {
@@ -122,12 +117,6 @@ public class GiteaSCMSourceContext
     @NonNull
     public GiteaSCMSourceContext wantReleases(boolean include) {
         wantReleases = wantReleases || include;
-        return this;
-    }
-
-    @NonNull
-    public GiteaSCMSourceContext includeDraftReleases(boolean include) {
-        includesDraftReleases = includesDraftReleases || include;
         return this;
     }
 

--- a/src/main/java/org/jenkinsci/plugin/gitea/GiteaSCMSourceContext.java
+++ b/src/main/java/org/jenkinsci/plugin/gitea/GiteaSCMSourceContext.java
@@ -38,6 +38,9 @@ public class GiteaSCMSourceContext
         extends SCMSourceContext<GiteaSCMSourceContext, GiteaSCMSourceRequest> {
     private boolean wantBranches;
     private boolean wantTags;
+    private boolean wantReleases;
+    private boolean includesDraftReleases;
+    private boolean includesPreReleases;
     private boolean wantOriginPRs;
     private boolean wantForkPRs;
     @NonNull
@@ -47,6 +50,7 @@ public class GiteaSCMSourceContext
     @NonNull
     private WebhookRegistration webhookRegistration = WebhookRegistration.SYSTEM;
     private boolean notificationsDisabled;
+    private boolean artifactToAssetMappingEnabled;
 
     public GiteaSCMSourceContext(@CheckForNull SCMSourceCriteria criteria, @NonNull SCMHeadObserver observer) {
         super(criteria, observer);
@@ -58,6 +62,18 @@ public class GiteaSCMSourceContext
 
     public final boolean wantTags() {
         return wantTags;
+    }
+
+    public final boolean wantReleases() {
+        return wantReleases;
+    }
+
+    public final boolean includesDraftReleases() {
+        return includesDraftReleases;
+    }
+
+    public final boolean includesPreReleases() {
+        return includesPreReleases;
     }
 
     public final boolean wantPRs() {
@@ -104,6 +120,28 @@ public class GiteaSCMSourceContext
     }
 
     @NonNull
+    public GiteaSCMSourceContext wantReleases(boolean include) {
+        wantReleases = wantReleases || include;
+        return this;
+    }
+
+    @NonNull
+    public GiteaSCMSourceContext includeDraftReleases(boolean include) {
+        includesDraftReleases = includesDraftReleases || include;
+        return this;
+    }
+
+    @NonNull
+    public GiteaSCMSourceContext includePreReleases(boolean include) {
+        includesPreReleases = includesPreReleases || include;
+        return this;
+    }
+
+    public final boolean artifactToAssetMappingEnabled() {
+        return artifactToAssetMappingEnabled;
+    }
+
+    @NonNull
     public GiteaSCMSourceContext wantOriginPRs(boolean include) {
         wantOriginPRs = wantOriginPRs || include;
         return this;
@@ -136,6 +174,12 @@ public class GiteaSCMSourceContext
     @NonNull
     public final GiteaSCMSourceContext withNotificationsDisabled(boolean disabled) {
         this.notificationsDisabled = disabled;
+        return this;
+    }
+
+    @NonNull
+    public final GiteaSCMSourceContext withArtifactToAssetMappingEnabled(boolean enabled) {
+        this.artifactToAssetMappingEnabled = enabled;
         return this;
     }
 

--- a/src/main/java/org/jenkinsci/plugin/gitea/GiteaSCMSourceRequest.java
+++ b/src/main/java/org/jenkinsci/plugin/gitea/GiteaSCMSourceRequest.java
@@ -51,7 +51,6 @@ public class GiteaSCMSourceRequest extends SCMSourceRequest {
     private final boolean fetchBranches;
     private final boolean fetchTags;
     private final boolean fetchReleases;
-    private final boolean includeDraftReleases;
     private final boolean includePreReleases;
     private final boolean fetchOriginPRs;
     private final boolean fetchForkPRs;
@@ -93,7 +92,6 @@ public class GiteaSCMSourceRequest extends SCMSourceRequest {
         fetchBranches = context.wantBranches();
         fetchTags = context.wantTags();
         fetchReleases = context.wantReleases();
-        includeDraftReleases = context.includesDraftReleases();
         includePreReleases = context.includesPreReleases();
         fetchOriginPRs = context.wantOriginPRs();
         fetchForkPRs = context.wantForkPRs();
@@ -157,10 +155,6 @@ public class GiteaSCMSourceRequest extends SCMSourceRequest {
      */
     public final boolean isFetchReleases() {
         return fetchReleases;
-    }
-
-    public final boolean isIncludingDraftReleases() {
-        return includeDraftReleases;
     }
 
     public final boolean isIncludingPreReleases() {

--- a/src/main/java/org/jenkinsci/plugin/gitea/ReleaseDiscoveryTrait.java
+++ b/src/main/java/org/jenkinsci/plugin/gitea/ReleaseDiscoveryTrait.java
@@ -1,0 +1,122 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017-2022, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugin.gitea;
+
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import jenkins.scm.api.SCMHeadCategory;
+import jenkins.scm.api.SCMSource;
+import jenkins.scm.api.trait.SCMSourceContext;
+import jenkins.scm.api.trait.SCMSourceTrait;
+import jenkins.scm.api.trait.SCMSourceTraitDescriptor;
+import jenkins.scm.impl.trait.Discovery;
+
+public class ReleaseDiscoveryTrait extends SCMSourceTrait {
+    private boolean includeDrafts;
+    private boolean includePreReleases;
+    private boolean artifactToAssetMappingEnabled;
+
+    @DataBoundConstructor
+    public ReleaseDiscoveryTrait(boolean includeDrafts, boolean includePreReleases) {
+        this.includeDrafts = includeDrafts;
+        this.includePreReleases = includePreReleases;
+    }
+
+    public boolean getIncludeDrafts() {
+        return includeDrafts;
+    }
+
+    @DataBoundSetter
+    public final void setIncludeDrafts(boolean includeDrafts) {
+        this.includeDrafts = includeDrafts;
+    }
+
+    public boolean getIncludePreReleases() {
+        return includePreReleases;
+    }
+
+    @DataBoundSetter
+    public final void setIncludePreReleases(boolean includePreReleases) {
+        this.includePreReleases = includePreReleases;
+    }
+
+    public boolean getArtifactToAssetMappingEnabled() {
+        return artifactToAssetMappingEnabled;
+    }
+
+    @DataBoundSetter
+    public final void setArtifactToAssetMappingEnabled(boolean artifactToAssetMappingEnabled) {
+        this.artifactToAssetMappingEnabled = artifactToAssetMappingEnabled;
+    }
+
+    @Override
+    protected void decorateContext(SCMSourceContext<?, ?> context) {
+        GiteaSCMSourceContext ctx = (GiteaSCMSourceContext) context;
+        ctx.wantReleases(true);
+        ctx.includeDraftReleases(this.includeDrafts);
+        ctx.includePreReleases(this.includePreReleases);
+        ctx.withArtifactToAssetMappingEnabled(this.artifactToAssetMappingEnabled);
+        //ctx.withAuthority(new TagSCMHeadAuthority());
+        // TODO: implement ReleaseSCMHeadAuthority
+    }
+
+    @Override
+    public boolean includeCategory(@NonNull SCMHeadCategory category) {
+        return category instanceof ReleaseSCMHeadCategory;
+    }
+
+    @Extension
+    @Discovery
+    @Symbol("giteaReleaseDiscovery")
+    public static class DescriptorImpl extends SCMSourceTraitDescriptor {
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public String getDisplayName() {
+            return Messages.ReleaseDiscoveryTrait_displayName();
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public Class<? extends SCMSourceContext> getContextClass() {
+            return GiteaSCMSourceContext.class;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public Class<? extends SCMSource> getSourceClass() {
+            return GiteaSCMSource.class;
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/plugin/gitea/ReleaseDiscoveryTrait.java
+++ b/src/main/java/org/jenkinsci/plugin/gitea/ReleaseDiscoveryTrait.java
@@ -36,23 +36,12 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
 public class ReleaseDiscoveryTrait extends SCMSourceTrait {
-    private boolean includeDrafts;
     private boolean includePreReleases;
     private boolean artifactToAssetMappingEnabled;
 
     @DataBoundConstructor
-    public ReleaseDiscoveryTrait(boolean includeDrafts, boolean includePreReleases) {
-        this.includeDrafts = includeDrafts;
+    public ReleaseDiscoveryTrait(boolean includePreReleases) {
         this.includePreReleases = includePreReleases;
-    }
-
-    public boolean getIncludeDrafts() {
-        return includeDrafts;
-    }
-
-    @DataBoundSetter
-    public final void setIncludeDrafts(boolean includeDrafts) {
-        this.includeDrafts = includeDrafts;
     }
 
     public boolean getIncludePreReleases() {
@@ -77,7 +66,6 @@ public class ReleaseDiscoveryTrait extends SCMSourceTrait {
     protected void decorateContext(SCMSourceContext<?, ?> context) {
         GiteaSCMSourceContext ctx = (GiteaSCMSourceContext) context;
         ctx.wantReleases(true);
-        ctx.includeDraftReleases(this.includeDrafts);
         ctx.includePreReleases(this.includePreReleases);
         ctx.withArtifactToAssetMappingEnabled(this.artifactToAssetMappingEnabled);
         //ctx.withAuthority(new TagSCMHeadAuthority());

--- a/src/main/java/org/jenkinsci/plugin/gitea/ReleaseDiscoveryTrait.java
+++ b/src/main/java/org/jenkinsci/plugin/gitea/ReleaseDiscoveryTrait.java
@@ -23,10 +23,6 @@
  */
 package org.jenkinsci.plugin.gitea;
 
-import org.jenkinsci.Symbol;
-import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.DataBoundSetter;
-
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import jenkins.scm.api.SCMHeadCategory;
@@ -35,6 +31,9 @@ import jenkins.scm.api.trait.SCMSourceContext;
 import jenkins.scm.api.trait.SCMSourceTrait;
 import jenkins.scm.api.trait.SCMSourceTraitDescriptor;
 import jenkins.scm.impl.trait.Discovery;
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 
 public class ReleaseDiscoveryTrait extends SCMSourceTrait {
     private boolean includeDrafts;

--- a/src/main/java/org/jenkinsci/plugin/gitea/ReleaseSCMHead.java
+++ b/src/main/java/org/jenkinsci/plugin/gitea/ReleaseSCMHead.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2017, CloudBees, Inc.
+ * Copyright (c) 2017-2022, CloudBees, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,40 +21,21 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.jenkinsci.plugin.gitea.client.api;
+package org.jenkinsci.plugin.gitea;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonValue;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import jenkins.scm.api.SCMHead;
 
-/**
- * Gitea event types.
- */
-public enum GiteaEventType {
-    CREATE("create"),
-    PUSH("push"),
-    PULL_REQUEST("pull_request"),
-    REPOSITORY("repository"),
-    DELETE("delete"),
-    RELEASE("release");
+public class ReleaseSCMHead extends SCMHead {
 
-    private final String key;
+    private final long id;
 
-    GiteaEventType(String key) {
-        this.key = key;
+    public ReleaseSCMHead(@NonNull String name, long id) {
+        super(name);
+        this.id = id;
     }
 
-    @JsonCreator
-    public static GiteaEventType fromString(String key) {
-        for (GiteaEventType s : values()) {
-            if (key.equals(s.key)) {
-                return s;
-            }
-        }
-        return null;
-    }
-
-    @JsonValue
-    public String getKey() {
-        return key;
+    public long getId() {
+        return id;
     }
 }

--- a/src/main/java/org/jenkinsci/plugin/gitea/ReleaseSCMHeadCategory.java
+++ b/src/main/java/org/jenkinsci/plugin/gitea/ReleaseSCMHeadCategory.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2017, CloudBees, Inc.
+ * Copyright (c) 2017-2022, CloudBees, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,40 +21,37 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.jenkinsci.plugin.gitea.client.api;
+package org.jenkinsci.plugin.gitea;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonValue;
+import org.jvnet.localizer.Localizable;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import jenkins.scm.api.SCMHead;
+import jenkins.scm.api.SCMHeadCategory;
 
 /**
- * Gitea event types.
+ * Category for {@link SCMHead} instances that implement {@link ReleaseSCMHead}.
  */
-public enum GiteaEventType {
-    CREATE("create"),
-    PUSH("push"),
-    PULL_REQUEST("pull_request"),
-    REPOSITORY("repository"),
-    DELETE("delete"),
-    RELEASE("release");
+public class ReleaseSCMHeadCategory extends SCMHeadCategory {
 
-    private final String key;
-
-    GiteaEventType(String key) {
-        this.key = key;
+    /**
+     * Constructs a {@link ReleaseSCMHeadCategory} with customized naming. Use this constructor when the generic
+     * naming is not appropriate terminology for the specific {@link SCMSource}'s naming of change requests.
+     *
+     * @param displayName the display name for change requests.
+     */
+    @SuppressFBWarnings("NP_METHOD_PARAMETER_TIGHTENS_ANNOTATION")
+    public ReleaseSCMHeadCategory(@NonNull Localizable displayName) {
+        super("gitea-releases", displayName);
     }
 
-    @JsonCreator
-    public static GiteaEventType fromString(String key) {
-        for (GiteaEventType s : values()) {
-            if (key.equals(s.key)) {
-                return s;
-            }
-        }
-        return null;
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isMatch(@NonNull SCMHead instance) {
+        return instance instanceof ReleaseSCMHead;
     }
-
-    @JsonValue
-    public String getKey() {
-        return key;
-    }
+    
 }

--- a/src/main/java/org/jenkinsci/plugin/gitea/ReleaseSCMHeadCategory.java
+++ b/src/main/java/org/jenkinsci/plugin/gitea/ReleaseSCMHeadCategory.java
@@ -29,6 +29,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMHeadCategory;
+import jenkins.scm.api.SCMSource;
 
 /**
  * Category for {@link SCMHead} instances that implement {@link ReleaseSCMHead}.

--- a/src/main/java/org/jenkinsci/plugin/gitea/ReleaseSCMHeadCategory.java
+++ b/src/main/java/org/jenkinsci/plugin/gitea/ReleaseSCMHeadCategory.java
@@ -23,13 +23,12 @@
  */
 package org.jenkinsci.plugin.gitea;
 
-import org.jvnet.localizer.Localizable;
-
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMHeadCategory;
 import jenkins.scm.api.SCMSource;
+import org.jvnet.localizer.Localizable;
 
 /**
  * Category for {@link SCMHead} instances that implement {@link ReleaseSCMHead}.
@@ -54,5 +53,5 @@ public class ReleaseSCMHeadCategory extends SCMHeadCategory {
     public boolean isMatch(@NonNull SCMHead instance) {
         return instance instanceof ReleaseSCMHead;
     }
-    
+
 }

--- a/src/main/java/org/jenkinsci/plugin/gitea/ReleaseSCMRevision.java
+++ b/src/main/java/org/jenkinsci/plugin/gitea/ReleaseSCMRevision.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2017, CloudBees, Inc.
+ * Copyright (c) 2017-2022, CloudBees, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,40 +21,14 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.jenkinsci.plugin.gitea.client.api;
+package org.jenkinsci.plugin.gitea;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonValue;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import jenkins.plugins.git.AbstractGitSCMSource;
 
-/**
- * Gitea event types.
- */
-public enum GiteaEventType {
-    CREATE("create"),
-    PUSH("push"),
-    PULL_REQUEST("pull_request"),
-    REPOSITORY("repository"),
-    DELETE("delete"),
-    RELEASE("release");
+public class ReleaseSCMRevision extends AbstractGitSCMSource.SCMRevisionImpl {
 
-    private final String key;
-
-    GiteaEventType(String key) {
-        this.key = key;
-    }
-
-    @JsonCreator
-    public static GiteaEventType fromString(String key) {
-        for (GiteaEventType s : values()) {
-            if (key.equals(s.key)) {
-                return s;
-            }
-        }
-        return null;
-    }
-
-    @JsonValue
-    public String getKey() {
-        return key;
+    public ReleaseSCMRevision(@NonNull ReleaseSCMHead head, @NonNull String hash) {
+        super(head, hash);
     }
 }

--- a/src/main/java/org/jenkinsci/plugin/gitea/client/api/GiteaConnection.java
+++ b/src/main/java/org/jenkinsci/plugin/gitea/client/api/GiteaConnection.java
@@ -24,6 +24,7 @@
 package org.jenkinsci.plugin.gitea.client.api;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.List;
 import java.util.Set;
 
@@ -70,6 +71,10 @@ public interface GiteaConnection extends AutoCloseable {
     GiteaAnnotatedTag fetchAnnotatedTag(String username, String repository, String sha1) throws IOException, InterruptedException;
 
     GiteaAnnotatedTag fetchAnnotatedTag(GiteaRepository repository, GiteaTag tag) throws IOException, InterruptedException;
+
+    GiteaTag fetchTag(String username, String repository, String tag) throws IOException, InterruptedException;
+
+    GiteaTag fetchTag(GiteaRepository repository, String tag) throws IOException, InterruptedException;
 
     List<GiteaTag> fetchTags(String username, String name) throws IOException, InterruptedException;
 
@@ -149,6 +154,16 @@ public interface GiteaConnection extends AutoCloseable {
     byte[] fetchFile(GiteaRepository repository, String ref, String path) throws IOException, InterruptedException;
 
     boolean checkFile(GiteaRepository repository, String ref, String path) throws IOException, InterruptedException;
+
+    List<GiteaRelease> fetchReleases(String username, String name, boolean draft, boolean prerelease) throws IOException, InterruptedException;
+
+    List<GiteaRelease> fetchReleases(GiteaRepository repository, boolean draft, boolean prerelease) throws IOException, InterruptedException;
+
+    GiteaRelease.Attachment createReleaseAttachment(String username, String repository, long id, String name, InputStream file)
+        throws IOException, InterruptedException;
+
+    GiteaRelease.Attachment createReleaseAttachment(GiteaRepository repository, long id, String name, InputStream file)
+        throws IOException, InterruptedException;
 
     /**
      * {@inheritDoc}

--- a/src/main/java/org/jenkinsci/plugin/gitea/client/api/GiteaRelease.java
+++ b/src/main/java/org/jenkinsci/plugin/gitea/client/api/GiteaRelease.java
@@ -136,7 +136,7 @@ public class GiteaRelease extends GiteaObject<GiteaRelease> {
     }
 
     public boolean isPrerelease() {
-        return draft;
+        return prerelease;
     }
 
     public void setPrerelease(boolean prerelease) {

--- a/src/main/java/org/jenkinsci/plugin/gitea/client/api/GiteaRelease.java
+++ b/src/main/java/org/jenkinsci/plugin/gitea/client/api/GiteaRelease.java
@@ -23,12 +23,11 @@
  */
 package org.jenkinsci.plugin.gitea.client.api;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
 
 @JsonIgnoreProperties(ignoreUnknown = Gitea.IGNORE_UNKNOWN_PROPERTIES)
 public class GiteaRelease extends GiteaObject<GiteaRelease> {
@@ -49,25 +48,6 @@ public class GiteaRelease extends GiteaObject<GiteaRelease> {
     private List<Attachment> assets = new ArrayList<>();
 
     public GiteaRelease() {
-    }
-
-    public GiteaRelease(String tagName, String targetCommitish, String name, String body,
-                        String url, String htmlUrl, String tarballUrl, String zipballUrl, boolean draft,
-                        boolean prerelease, Date createdAt, Date publishedAt, GiteaOwner author, List<Attachment> assets) {
-        this.tagName = tagName;
-        this.targetCommitish = targetCommitish;
-        this.name = name;
-        this.body = body;
-        this.url = url;
-        this.htmlUrl = htmlUrl;
-        this.tarballUrl = tarballUrl;
-        this.zipballUrl = zipballUrl;
-        this.draft = draft;
-        this.prerelease = prerelease;
-        this.createdAt = createdAt;
-        this.publishedAt = publishedAt;
-        this.author = author;
-        this.assets = assets;
     }
 
     public long getId() {
@@ -223,16 +203,6 @@ public class GiteaRelease extends GiteaObject<GiteaRelease> {
         public Attachment() {
         }
 
-        public Attachment(String name, long size, long downloadCount, Date createdAt,
-                          String uuid, String browserDownloadUrl) {
-            this.name = name;
-            this.size = size;
-            this.downloadCount = downloadCount;
-            this.createdAt = createdAt;
-            this.uuid = uuid;
-            this.browserDownloadUrl = browserDownloadUrl;
-        }
-
         public long getId() {
             return id;
         }
@@ -269,7 +239,7 @@ public class GiteaRelease extends GiteaObject<GiteaRelease> {
         public Date getCreatedAt() {
             return createdAt == null ? null : (Date) createdAt.clone();
         }
-    
+
         @JsonProperty("created_at")
         public void setCreatedAt(Date createdAt) {
             this.createdAt = createdAt == null ? null : (Date) createdAt.clone();

--- a/src/main/java/org/jenkinsci/plugin/gitea/client/api/GiteaRelease.java
+++ b/src/main/java/org/jenkinsci/plugin/gitea/client/api/GiteaRelease.java
@@ -1,0 +1,310 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017-2022, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugin.gitea.client.api;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = Gitea.IGNORE_UNKNOWN_PROPERTIES)
+public class GiteaRelease extends GiteaObject<GiteaRelease> {
+    private long id;
+    private String tagName;
+    private String targetCommitish;
+    private String name;
+    private String body;
+    private String url;
+    private String htmlUrl;
+    private String tarballUrl;
+    private String zipballUrl;
+    private boolean draft;
+    private boolean prerelease;
+    private Date createdAt;
+    private Date publishedAt;
+    private GiteaOwner author;
+    private List<Attachment> assets = new ArrayList<>();
+
+    public GiteaRelease() {
+    }
+
+    public GiteaRelease(String tagName, String targetCommitish, String name, String body,
+                        String url, String htmlUrl, String tarballUrl, String zipballUrl, boolean draft,
+                        boolean prerelease, Date createdAt, Date publishedAt, GiteaOwner author, List<Attachment> assets) {
+        this.tagName = tagName;
+        this.targetCommitish = targetCommitish;
+        this.name = name;
+        this.body = body;
+        this.url = url;
+        this.htmlUrl = htmlUrl;
+        this.tarballUrl = tarballUrl;
+        this.zipballUrl = zipballUrl;
+        this.draft = draft;
+        this.prerelease = prerelease;
+        this.createdAt = createdAt;
+        this.publishedAt = publishedAt;
+        this.author = author;
+        this.assets = assets;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public String getTagName() {
+        return tagName;
+    }
+
+    @JsonProperty("tag_name")
+    public void setTagName(String tagName) {
+        this.tagName = tagName;
+    }
+
+    public String getTargetCommitish() {
+        return targetCommitish;
+    }
+
+    @JsonProperty("target_commitish")
+    public void setTargetCommitish(String targetCommitish) {
+        this.targetCommitish = targetCommitish;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getBody() {
+        return body;
+    }
+
+    public void setBody(String body) {
+        this.body = body;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    public String getHtmlUrl() {
+        return htmlUrl;
+    }
+
+    @JsonProperty("html_url")
+    public void setHtmlUrl(String htmlUrl) {
+        this.htmlUrl = htmlUrl;
+    }
+
+    public String getTarballUrl() {
+        return tarballUrl;
+    }
+
+    @JsonProperty("tarball_url")
+    public void setTarballUrl(String tarballUrl) {
+        this.tarballUrl = tarballUrl;
+    }
+
+    public String getZipballUrl() {
+        return zipballUrl;
+    }
+
+    @JsonProperty("zipball_url")
+    public void setZipballUrl(String zipballUrl) {
+        this.zipballUrl = zipballUrl;
+    }
+
+    public boolean isDraft() {
+        return draft;
+    }
+
+    public void setDraft(boolean draft) {
+        this.draft = draft;
+    }
+
+    public boolean isPrerelease() {
+        return draft;
+    }
+
+    public void setPrerelease(boolean prerelease) {
+        this.prerelease = prerelease;
+    }
+
+    public Date getCreatedAt() {
+        return createdAt == null ? null : (Date) createdAt.clone();
+    }
+
+    @JsonProperty("created_at")
+    public void setCreatedAt(Date createdAt) {
+        this.createdAt = createdAt == null ? null : (Date) createdAt.clone();
+    }
+
+    public Date getPublishedAt() {
+        return publishedAt == null ? null : (Date) publishedAt.clone();
+    }
+
+    @JsonProperty("published_at")
+    public void setPublishedAt(Date publishedAt) {
+        this.publishedAt = publishedAt == null ? null : (Date) publishedAt.clone();
+    }
+
+    public GiteaOwner getAuthor() {
+        return author == null ? null : author.clone();
+    }
+
+    public void setAuthor(GiteaOwner author) {
+        this.author = author == null ? null : author.clone();
+    }
+
+    @Override
+    public String toString() {
+        return "GiteaRelease{" +
+                "id=" + id +
+                ", tagName='" + tagName + '\'' +
+                ", targetCommitish='" + targetCommitish + '\'' +
+                ", name='" + name + '\'' +
+                ", body='" + body + '\'' +
+                ", url='" + url + '\'' +
+                ", htmlUrl='" + htmlUrl + '\'' +
+                ", tarballUrl='" + tarballUrl + '\'' +
+                ", zipballUrl='" + zipballUrl + '\'' +
+                ", draft=" + draft +
+                ", prerelease=" + prerelease +
+                ", createdAt=" + createdAt +
+                ", publishedAt=" + publishedAt +
+                ", author=" + author +
+                ", assets=" + assets +
+                '}';
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = Gitea.IGNORE_UNKNOWN_PROPERTIES)
+    public static class Attachment extends GiteaObject<Attachment> {
+        private long id;
+        private String name;
+        private long size;
+        private long downloadCount;
+        private Date createdAt;
+        private String uuid;
+        private String browserDownloadUrl;
+
+        public Attachment() {
+        }
+
+        public Attachment(String name, long size, long downloadCount, Date createdAt,
+                          String uuid, String browserDownloadUrl) {
+            this.name = name;
+            this.size = size;
+            this.downloadCount = downloadCount;
+            this.createdAt = createdAt;
+            this.uuid = uuid;
+            this.browserDownloadUrl = browserDownloadUrl;
+        }
+
+        public long getId() {
+            return id;
+        }
+
+        public void setId(long id) {
+            this.id = id;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public long getSize() {
+            return size;
+        }
+
+        public void setSize(long size) {
+            this.size = size;
+        }
+
+        public long getDownloadCount() {
+            return downloadCount;
+        }
+
+        @JsonProperty("download_count")
+        public void setDownloadCount(long downloadCount) {
+            this.downloadCount = downloadCount;
+        }
+
+        public Date getCreatedAt() {
+            return createdAt == null ? null : (Date) createdAt.clone();
+        }
+    
+        @JsonProperty("created_at")
+        public void setCreatedAt(Date createdAt) {
+            this.createdAt = createdAt == null ? null : (Date) createdAt.clone();
+        }
+
+        public String getUuid() {
+            return uuid;
+        }
+
+        public void setUuid(String uuid) {
+            this.uuid = uuid;
+        }
+
+        public String getBrowserDownloadUrl() {
+            return browserDownloadUrl;
+        }
+
+        @JsonProperty("browser_download_url")
+        public void setBrowserDownloadUrl(String browserDownloadUrl) {
+            this.browserDownloadUrl = browserDownloadUrl;
+        }
+
+        @Override
+        public String toString() {
+            return "Attachment{" +
+                    "id=" + id +
+                    ", admin='" + name + '\'' +
+                    ", size=" + size +
+                    ", downloadCount=" + downloadCount +
+                    ", createdAt=" + createdAt +
+                    ", uuid=" + uuid +
+                    ", browserDownloadUrl=" + browserDownloadUrl +
+                    '}';
+        }
+
+    }
+
+}

--- a/src/main/java/org/jenkinsci/plugin/gitea/client/api/GiteaReleaseEvent.java
+++ b/src/main/java/org/jenkinsci/plugin/gitea/client/api/GiteaReleaseEvent.java
@@ -1,0 +1,86 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017-2022, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugin.gitea.client.api;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * Gitea {@link GiteaEventType#RELEASE} event.
+ */
+@JsonIgnoreProperties(ignoreUnknown = Gitea.IGNORE_UNKNOWN_PROPERTIES)
+public class GiteaReleaseEvent extends GiteaEvent {
+    private GiteaReleaseEventType action;
+    private GiteaRelease release;
+    private GiteaRepository repository;
+    private GiteaOwner sender;
+
+    @Override
+    public GiteaReleaseEvent clone() {
+        return (GiteaReleaseEvent) super.clone();
+    }
+
+    @Override
+    public String toString() {
+        return "GiteaReleaseEvent{" +
+                super.toString() +
+                ", action=" + action +
+                ", release=" + release +
+                ", repository=" + repository +
+                ", sender=" + sender +
+                '}';
+    }
+
+    public GiteaReleaseEventType getAction() {
+        return action;
+    }
+
+    public void setAction(GiteaReleaseEventType action) {
+        this.action = action;
+    }
+
+    public GiteaRelease getRelease() {
+        return release == null ? null : release.clone();
+    }
+
+    public void setRelease(GiteaRelease release) {
+        this.release = release == null ? null : release.clone();
+    }
+
+    public GiteaRepository getRepository() {
+        return repository == null ? null : repository.clone();
+    }
+
+    public void setRepository(GiteaRepository repository) {
+        this.repository = repository == null ? null : repository.clone();
+    }
+
+    public GiteaOwner getSender() {
+        return sender == null ? null : sender.clone();
+    }
+
+    public void setSender(GiteaOwner sender) {
+        this.sender = sender == null ? null : sender.clone();
+    }
+
+}

--- a/src/main/java/org/jenkinsci/plugin/gitea/client/api/GiteaReleaseEventType.java
+++ b/src/main/java/org/jenkinsci/plugin/gitea/client/api/GiteaReleaseEventType.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2017, CloudBees, Inc.
+ * Copyright (c) 2017-2022, CloudBees, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -26,26 +26,20 @@ package org.jenkinsci.plugin.gitea.client.api;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-/**
- * Gitea event types.
- */
-public enum GiteaEventType {
-    CREATE("create"),
-    PUSH("push"),
-    PULL_REQUEST("pull_request"),
-    REPOSITORY("repository"),
-    DELETE("delete"),
-    RELEASE("release");
+public enum GiteaReleaseEventType {
+    PUBLISHED("published"),
+    UPDATED("updated"),
+    DELETED("deleted");
 
     private final String key;
 
-    GiteaEventType(String key) {
+    GiteaReleaseEventType(String key) {
         this.key = key;
     }
 
     @JsonCreator
-    public static GiteaEventType fromString(String key) {
-        for (GiteaEventType s : values()) {
+    public static GiteaReleaseEventType fromString(String key) {
+        for (GiteaReleaseEventType s : values()) {
             if (key.equals(s.key)) {
                 return s;
             }

--- a/src/main/java/org/jenkinsci/plugin/gitea/client/impl/DefaultGiteaConnection.java
+++ b/src/main/java/org/jenkinsci/plugin/gitea/client/impl/DefaultGiteaConnection.java
@@ -72,7 +72,6 @@ import org.jenkinsci.plugin.gitea.client.api.GiteaOrganization;
 import org.jenkinsci.plugin.gitea.client.api.GiteaOwner;
 import org.jenkinsci.plugin.gitea.client.api.GiteaPullRequest;
 import org.jenkinsci.plugin.gitea.client.api.GiteaRelease;
-import org.jenkinsci.plugin.gitea.client.api.GiteaRelease.Attachment;
 import org.jenkinsci.plugin.gitea.client.api.GiteaRepository;
 import org.jenkinsci.plugin.gitea.client.api.GiteaTag;
 import org.jenkinsci.plugin.gitea.client.api.GiteaUser;
@@ -875,7 +874,7 @@ class DefaultGiteaConnection implements GiteaConnection {
     }
 
     @Override
-    public GiteaRelease.Attachment createReleaseAttachment(String username, String repository, long id, 
+    public GiteaRelease.Attachment createReleaseAttachment(String username, String repository, long id,
                                                            String name, InputStream file)
             throws IOException, InterruptedException {
         return postFile(api()
@@ -1016,7 +1015,8 @@ class DefaultGiteaConnection implements GiteaConnection {
         connection.setDoInput(!Void.class.equals(modelClass));
 
         final String LINE_FEED = "\r\n";
-        PrintWriter writer = new PrintWriter(new OutputStreamWriter(connection.getOutputStream()), true);
+        // Default charset is utf8 for forms: https://www.rfc-editor.org/rfc/rfc7578#section-5.1.2
+        PrintWriter writer = new PrintWriter(new OutputStreamWriter(connection.getOutputStream(), "UTF-8"), true);
         {
             writer.append("--" + boundary).append(LINE_FEED);
             writer.append("Content-Disposition: form-data; name=\"attachment\"; filename=\"" + fileName + "\"").append(LINE_FEED);
@@ -1024,7 +1024,7 @@ class DefaultGiteaConnection implements GiteaConnection {
             writer.append("Content-Transfer-Encoding: binary").append(LINE_FEED);
             writer.append(LINE_FEED);
             writer.flush();
-    
+
             byte[] buffer = new byte[4096];
             int bytesRead = -1;
             while ((bytesRead = file.read(buffer)) != -1) {
@@ -1032,7 +1032,7 @@ class DefaultGiteaConnection implements GiteaConnection {
             }
             connection.getOutputStream().flush();
             file.close();
-    
+
             writer.append(LINE_FEED);
             writer.flush();
         }

--- a/src/main/java/org/jenkinsci/plugin/gitea/client/impl/DefaultGiteaConnection.java
+++ b/src/main/java/org/jenkinsci/plugin/gitea/client/impl/DefaultGiteaConnection.java
@@ -1033,7 +1033,6 @@ class DefaultGiteaConnection implements GiteaConnection {
             connection.getOutputStream().flush();
             file.close();
 
-            writer.append(LINE_FEED);
             writer.flush();
         }
 

--- a/src/main/java/org/jenkinsci/plugin/gitea/client/impl/DefaultGiteaConnection.java
+++ b/src/main/java/org/jenkinsci/plugin/gitea/client/impl/DefaultGiteaConnection.java
@@ -846,13 +846,12 @@ class DefaultGiteaConnection implements GiteaConnection {
                             .path(UriTemplateBuilder.var("username"))
                             .path(UriTemplateBuilder.var("name"))
                             .literal("/releases")
-                            .query(UriTemplateBuilder.var("draft"))
-                            .query(UriTemplateBuilder.var("preRelease"))
+                            // Unfortunately, "pre-release" is not a valid variable name.
+                            // So we have to craft the query part on our own.
+                            .literal("?draft=" + draft + "&pre-release=" + prerelease)
                             .build()
                             .set("username", username)
-                            .set("name", name)
-                            .set("draft", draft)
-                            .set("preRelease", prerelease),
+                            .set("name", name),
                     GiteaRelease.class
             );
         } catch (GiteaHttpStatusException e) {

--- a/src/main/java/org/jenkinsci/plugin/gitea/tasks/GiteaAssetPublisher.java
+++ b/src/main/java/org/jenkinsci/plugin/gitea/tasks/GiteaAssetPublisher.java
@@ -1,0 +1,314 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017-2022, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugin.gitea.tasks;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.apache.tools.ant.types.FileSet;
+import org.jenkinsci.Symbol;
+import org.jenkinsci.plugin.gitea.GiteaSCMSource;
+import org.jenkinsci.plugin.gitea.Messages;
+import org.jenkinsci.plugin.gitea.ReleaseSCMHead;
+import org.jenkinsci.plugin.gitea.client.api.GiteaConnection;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+import org.kohsuke.stapler.StaplerRequest;
+
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import hudson.AbortException;
+import hudson.EnvVars;
+import hudson.Extension;
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.Util;
+import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
+import hudson.model.Action;
+import hudson.model.BuildListener;
+import hudson.model.Describable;
+import hudson.model.Descriptor;
+import hudson.model.Result;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.remoting.Pipe;
+import hudson.remoting.VirtualChannel;
+import hudson.tasks.BuildStepDescriptor;
+import hudson.util.IOUtils;
+import jenkins.MasterToSlaveFileCallable;
+import jenkins.SlaveToMasterFileCallable;
+import jenkins.model.Jenkins;
+import jenkins.scm.api.SCMHead;
+import jenkins.scm.api.SCMSource;
+import jenkins.tasks.SimpleBuildStep;
+import net.sf.json.JSONObject;
+
+public class GiteaAssetPublisher implements SimpleBuildStep, Describable<GiteaAssetPublisher> {
+
+    private static final Logger LOGGER = Logger.getLogger(GiteaAssetPublisher.class.getName());
+
+    private String assets;
+    private String excludes;
+    private boolean onlyIfSuccessful;
+    private Boolean defaultExcludes = true;
+    private Boolean caseSensitive = true;
+    private Boolean followSymlinks = true;
+
+    @DataBoundConstructor
+    public GiteaAssetPublisher(String assets) {
+        this.assets = assets.trim();
+    }
+
+    public String getAssets() {
+        return assets;
+    }
+
+    public @CheckForNull String getExcludes() {
+        return excludes;
+    }
+
+    @DataBoundSetter
+    public final void setExcludes(@CheckForNull String excludes) {
+        this.excludes = Util.fixEmptyAndTrim(excludes);
+    }
+
+    public boolean isOnlyIfSuccessful() {
+        return onlyIfSuccessful;
+    }
+
+    @DataBoundSetter
+    public final void setOnlyIfSuccessful(boolean onlyIfSuccessful) {
+        this.onlyIfSuccessful = onlyIfSuccessful;
+    }
+
+    public boolean isDefaultExcludes() {
+        return defaultExcludes;
+    }
+
+    @DataBoundSetter
+    public final void setDefaultExcludes(boolean defaultExcludes) {
+        this.defaultExcludes = defaultExcludes;
+    }
+    
+    public boolean isCaseSensitive() {
+        return caseSensitive;
+    }
+
+    @DataBoundSetter
+    public final void setCaseSensitive(boolean caseSensitive) {
+        this.caseSensitive = caseSensitive;
+    }
+
+    public boolean isFollowSymlinks() {
+        return followSymlinks;
+    }
+
+    @DataBoundSetter
+    public final void setFollowSymlinks(boolean followSymlinks) {
+        this.followSymlinks = followSymlinks;
+    }
+
+    @Override
+    public boolean prebuild(AbstractBuild<?, ?> build, BuildListener listener) {
+        return true;
+    }
+
+    @Override
+    public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
+            throws InterruptedException, IOException {
+        throw new IllegalStateException("GiteaAssetPublisher.perform(AbstractBuild, Launcher, BuildListener) should not have been called...");
+    }
+
+    public void perform(Run<?, ?> build, FilePath workspace, Launcher launcher, TaskListener listener)
+            throws InterruptedException, IOException {
+
+        if(assets.length()==0) {
+            throw new AbortException(Messages.GiteaAssetPublisher_NoIncludes());
+        }
+
+        Result result = build.getResult();
+        if (onlyIfSuccessful && result != null && result.isWorseThan(Result.UNSTABLE)) {
+            listener.getLogger().println(Messages.GiteaAssetPublisher_SkipBecauseOnlyIfSuccessful());
+            return;
+        }
+
+        final SCMSource s = SCMSource.SourceByItem.findSource(build.getParent());
+        if (!(s instanceof GiteaSCMSource)) {
+            listener.getLogger().println("Did not publish gitea release assets due to source being no GiteaSCMSource");
+            return;
+        }
+        final GiteaSCMSource source = (GiteaSCMSource) s;
+        final SCMHead head = SCMHead.HeadByItem.findHead(build.getParent());
+        if (head == null || !(head instanceof ReleaseSCMHead)) {
+            listener.getLogger().println("Did not publish gitea release assets due to head either being null or no ReleaseSCMHead");
+            return;
+        }
+
+        listener.getLogger().println(Messages.GiteaAssetPublisher_StartPublishing());
+        EnvVars environment = build.getEnvironment(listener);
+
+        try {
+            String assets = this.assets;
+            if (build instanceof AbstractBuild) { // no expansion in pipelines
+                assets = environment.expand(assets);
+            }
+
+            // Map<archivedPath, workspacePath>
+            // 
+            Map<String,String> files = workspace.act(new ListFiles(assets, excludes, defaultExcludes, caseSensitive, followSymlinks));
+            if (!files.isEmpty()) {
+                // now publish all files...
+
+                // final DirScanner scanner = new FilePath.ExplicitlySpecifiedDirScanner(files);
+                // Future<Integer> future = workspace.actAsync(new StreamRecursiveRemoteToLocal(pipe, scanner, FilePath.TarCompression.NONE));
+
+                for (Map.Entry<String, String> entry : files.entrySet()) {
+                    String archivedPath = entry.getKey();
+                    assert archivedPath.indexOf('\\') == -1;
+                    String workspacePath = entry.getValue();
+                    assert workspacePath.indexOf('\\') == -1;
+
+                    listener.getLogger().format("GiteaAssetPublisher: %s -> %s%n", archivedPath, workspacePath);
+
+                    final Pipe pipe = Pipe.createRemoteToLocal();
+                    workspace.act(new StreamFileRemoteToLocal(pipe, workspacePath));
+                    // pipe now *should* contain the entire file...
+
+                    try (GiteaConnection c = source.gitea().open()) {
+                        c.createReleaseAttachment(
+                            source.getRepoOwner(), source.getRepository(), ((ReleaseSCMHead) head).getId(),
+                            new File(archivedPath).getName(), pipe.getIn());
+                    }
+                }
+            } else {
+                result = build.getResult();
+                //noinspection StatementWithEmptyBody
+                if (result == null || result.isBetterOrEqualTo(Result.UNSTABLE)) {
+                    //if (allowEmptyArchive) {
+                    //    listener.getLogger().println(Messages.ArtifactArchiver_NoMatchFound(artifacts));
+                    //} else {
+                    //    throw new AbortException(Messages.ArtifactArchiver_NoMatchFound(artifacts));
+                    //}
+                }
+            }
+        } catch (java.nio.file.AccessDeniedException e) {
+            LOGGER.log(Level.FINE, "Diagnosing anticipated Exception", e);
+            throw new AbortException(e.toString()); // Message is not enough as that is the filename only
+        }
+    }
+
+    private static final class StreamFileRemoteToLocal extends SlaveToMasterFileCallable<Void> {
+        private final Pipe pipe;
+        private final String workspacePath;
+
+        StreamFileRemoteToLocal(Pipe pipe, String workspacePath) {
+            this.pipe = pipe;
+            this.workspacePath = workspacePath;
+        }
+
+        @Override
+        public Void invoke(File f, VirtualChannel channel) throws IOException, InterruptedException {
+            File file = new File(f, workspacePath);
+            if (file.isDirectory()) {
+                return null;
+            }
+            try (OutputStream out = pipe.getOut()) {
+                IOUtils.copy(file, out);
+            }
+            return null;
+        }
+    }
+
+    private static final class ListFiles extends MasterToSlaveFileCallable<Map<String,String>> {
+        private final String includes, excludes;
+        private final boolean defaultExcludes;
+        private final boolean caseSensitive;
+        private final boolean followSymlinks;
+
+        ListFiles(String includes, String excludes, boolean defaultExcludes, boolean caseSensitive, boolean followSymlinks) {
+            this.includes = includes;
+            this.excludes = excludes;
+            this.defaultExcludes = defaultExcludes;
+            this.caseSensitive = caseSensitive;
+            this.followSymlinks = followSymlinks;
+        }
+
+        @Override
+        public Map<String, String> invoke(File basedir, VirtualChannel channel) throws IOException, InterruptedException {
+            Map<String,String> r = new HashMap<>();
+
+            FileSet fileSet = Util.createFileSet(basedir, includes, excludes);
+            fileSet.setDefaultexcludes(defaultExcludes);
+            fileSet.setCaseSensitive(caseSensitive);
+            fileSet.setFollowSymlinks(followSymlinks);
+
+            for (String f : fileSet.getDirectoryScanner().getIncludedFiles()) {
+                f = f.replace(File.separatorChar, '/');
+                r.put(f, f);
+            }
+            return r;
+        }
+    }
+
+    @Override
+    public Action getProjectAction(AbstractProject<?, ?> project) {
+        return null;
+    }
+
+    @Override
+    public Collection<? extends Action> getProjectActions(AbstractProject<?, ?> project) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public Descriptor<GiteaAssetPublisher> getDescriptor() {
+        return Jenkins.get().getDescriptorOrDie(getClass());
+    }
+
+    @Extension @Symbol("publishGiteaAsset")
+    public static final class DescriptorImpl extends BuildStepDescriptor<GiteaAssetPublisher> {
+
+        @Override
+        public boolean isApplicable(Class<? extends AbstractProject> jobType) {
+            return true;
+        }
+
+        @Override
+        public GiteaAssetPublisher newInstance(StaplerRequest req, JSONObject formData) throws FormException {
+            return req.bindJSON(GiteaAssetPublisher.class,formData);
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "Publishes an asset to the gitea release, if the build was triggered by an release";
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/plugin/gitea/tasks/GiteaAssetPublisher.java
+++ b/src/main/java/org/jenkinsci/plugin/gitea/tasks/GiteaAssetPublisher.java
@@ -293,7 +293,7 @@ public class GiteaAssetPublisher implements SimpleBuildStep, Describable<GiteaAs
         return Jenkins.get().getDescriptorOrDie(getClass());
     }
 
-    @Extension @Symbol("publishGiteaAsset")
+    @Extension @Symbol("publishGiteaAssets")
     public static final class DescriptorImpl extends BuildStepDescriptor<GiteaAssetPublisher> {
 
         @Override

--- a/src/main/resources/org/jenkinsci/plugin/gitea/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugin/gitea/Messages.properties
@@ -46,8 +46,10 @@ ReleaseDiscoveryTrait.displayName=Discover Gitea releases
 GiteaSCMSource.ReleaseCategory=Releases
 
 GiteaAssetPublisher.StartPublishing=Publishing Gitea release assets
+GiteaAssetPublisher.DisplayName=Publishes an asset to the gitea release, if the build was triggered by an release
 GiteaAssetPublisher.SkipBecauseOnlyIfSuccessful=Skipped archiving because build is not successful
 GiteaAssetPublisher.NoIncludes=\
 No assets are configured for publishing.\n\
 You probably forgot to set the file pattern, so please go back to the configuration and specify it.\n\
 If you really did mean to publish all the files in the workspace, please specify "**"
+GiteaAssetPublisher.NoMatchFound=No assets found that match the file pattern "{0}". Configuration error?

--- a/src/main/resources/org/jenkinsci/plugin/gitea/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugin/gitea/Messages.properties
@@ -42,3 +42,12 @@ WebhookRegistrationTrait.displayName=Override hook management
 WebhookRegistrationTrait.useItemHook=Use item credentials for hook management
 TagDiscoveryTrait.displayName=Discover tags
 TagDiscoveryTrait.authorityDisplayName=Trust tags
+ReleaseDiscoveryTrait.displayName=Discover Gitea releases
+GiteaSCMSource.ReleaseCategory=Releases
+
+GiteaAssetPublisher.StartPublishing=Publishing Gitea release assets
+GiteaAssetPublisher.SkipBecauseOnlyIfSuccessful=Skipped archiving because build is not successful
+GiteaAssetPublisher.NoIncludes=\
+No assets are configured for publishing.\n\
+You probably forgot to set the file pattern, so please go back to the configuration and specify it.\n\
+If you really did mean to publish all the files in the workspace, please specify "**"

--- a/src/main/resources/org/jenkinsci/plugin/gitea/ReleaseDiscoveryTrait/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugin/gitea/ReleaseDiscoveryTrait/config.jelly
@@ -1,9 +1,6 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:c="/lib/credentials"
          xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <f:entry field="includeDrafts">
-    <f:checkbox title="Include drafts"/>
-  </f:entry>
   <f:entry field="includePreReleases">
     <f:checkbox title="Include pre-releases"/>
   </f:entry>

--- a/src/main/resources/org/jenkinsci/plugin/gitea/ReleaseDiscoveryTrait/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugin/gitea/ReleaseDiscoveryTrait/config.jelly
@@ -1,0 +1,13 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:c="/lib/credentials"
+         xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <f:entry field="includeDrafts">
+    <f:checkbox title="Include drafts"/>
+  </f:entry>
+  <f:entry field="includePreReleases">
+    <f:checkbox title="Include pre-releases"/>
+  </f:entry>
+  <f:entry field="artifactToAssetMappingEnabled">
+    <f:checkbox title="Enable artifact to release asset mapping"/>
+  </f:entry>
+</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugin/gitea/ReleaseDiscoveryTrait/help-artifactToAssetMappingEnabled.html
+++ b/src/main/resources/org/jenkinsci/plugin/gitea/ReleaseDiscoveryTrait/help-artifactToAssetMappingEnabled.html
@@ -1,0 +1,4 @@
+<div>
+    If enabled, artifacts that where archived (i.e. via <code>archiveArtifacts</code>) will be added
+    as assets in the release, but only if the build was successfull.
+</div>

--- a/src/main/resources/org/jenkinsci/plugin/gitea/ReleaseDiscoveryTrait/help-includeDrafts.html
+++ b/src/main/resources/org/jenkinsci/plugin/gitea/ReleaseDiscoveryTrait/help-includeDrafts.html
@@ -1,3 +1,0 @@
-<div>
-    If enabled, releases that are marked as drafts are also discovered
-</div>

--- a/src/main/resources/org/jenkinsci/plugin/gitea/ReleaseDiscoveryTrait/help-includeDrafts.html
+++ b/src/main/resources/org/jenkinsci/plugin/gitea/ReleaseDiscoveryTrait/help-includeDrafts.html
@@ -1,0 +1,3 @@
+<div>
+    If enabled, releases that are marked as drafts are also discovered
+</div>

--- a/src/main/resources/org/jenkinsci/plugin/gitea/ReleaseDiscoveryTrait/help-includePreReleases.html
+++ b/src/main/resources/org/jenkinsci/plugin/gitea/ReleaseDiscoveryTrait/help-includePreReleases.html
@@ -1,0 +1,3 @@
+<div>
+    If enabled, releases that are marked as pre-release are also discovered
+</div>

--- a/src/main/resources/org/jenkinsci/plugin/gitea/ReleaseDiscoveryTrait/help.html
+++ b/src/main/resources/org/jenkinsci/plugin/gitea/ReleaseDiscoveryTrait/help.html
@@ -1,0 +1,3 @@
+<div>
+    Discovers releases on the repository.
+</div>

--- a/src/main/resources/org/jenkinsci/plugin/gitea/tasks/GiteaAssetPublisher/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugin/gitea/tasks/GiteaAssetPublisher/config.jelly
@@ -1,0 +1,24 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
+    xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <f:entry title="${%Files to publish}" field="assets">
+    <f:textbox />
+  </f:entry>
+  <f:advanced>
+    <f:entry title="${%Excludes}" field="excludes">
+      <f:textbox />
+    </f:entry>
+    <f:entry field="onlyIfSuccessful">
+      <f:checkbox title="${%onlyIfSuccessful}" />
+    </f:entry>
+    <f:entry field="defaultExcludes">
+      <f:checkbox title="${%defaultExcludes}" default="true" />
+    </f:entry>
+    <f:entry field="caseSensitive">
+      <f:checkbox title="${%caseSensitive}" default="true" />
+    </f:entry>
+    <f:entry field="followSymlinks" >
+      <f:checkbox title="${%followSymlinks}" default="false"/>
+    </f:entry>
+  </f:advanced>
+</j:jelly>

--- a/src/test/java/org/jenkinsci/plugin/gitea/client/mock/MockGiteaConnection.java
+++ b/src/test/java/org/jenkinsci/plugin/gitea/client/mock/MockGiteaConnection.java
@@ -3,6 +3,7 @@ package org.jenkinsci.plugin.gitea.client.mock;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
@@ -27,6 +28,7 @@ import org.jenkinsci.plugin.gitea.client.api.GiteaObject;
 import org.jenkinsci.plugin.gitea.client.api.GiteaOrganization;
 import org.jenkinsci.plugin.gitea.client.api.GiteaOwner;
 import org.jenkinsci.plugin.gitea.client.api.GiteaPullRequest;
+import org.jenkinsci.plugin.gitea.client.api.GiteaRelease;
 import org.jenkinsci.plugin.gitea.client.api.GiteaRepository;
 import org.jenkinsci.plugin.gitea.client.api.GiteaTag;
 import org.jenkinsci.plugin.gitea.client.api.GiteaUser;
@@ -46,6 +48,7 @@ public class MockGiteaConnection implements GiteaConnection {
     private final Map<String, List<GiteaHook>> orgHooks = new TreeMap<>();
     private final Map<String, List<GiteaHook>> repoHooks = new TreeMap<>();
     private final Map<String, Map<String, Map<String,byte[]>>> files = new TreeMap<>();
+    private final Map<String, Map<Long, GiteaRelease>> releases = new TreeMap<>();
 
     public MockGiteaConnection(String user) {
         this.user = user;
@@ -409,6 +412,18 @@ public class MockGiteaConnection implements GiteaConnection {
     }
 
     @Override
+    public GiteaTag fetchTag(String username, String repository, String tag) throws IOException, InterruptedException {
+        // TODO
+        return null;
+    }
+
+    @Override
+    public GiteaTag fetchTag(GiteaRepository repository, String tag) throws IOException, InterruptedException {
+        // TODO
+        return null;
+    }
+
+    @Override
     public List<GiteaTag> fetchTags(String username, String name) throws IOException, InterruptedException {
         // TODO
         return null;
@@ -514,6 +529,35 @@ public class MockGiteaConnection implements GiteaConnection {
     public boolean checkFile(GiteaRepository repository, String ref, String path)
             throws IOException, InterruptedException {
         return notFoundIfNull(notFoundIfNull(files.get(keyOf(repository))).get(ref)).containsKey(path);
+    }
+
+    @Override
+    public List<GiteaRelease> fetchReleases(String username, String name, boolean draft, boolean prerelease)
+            throws IOException, InterruptedException {
+        List<GiteaRelease> result = new ArrayList<>();
+        for (GiteaRelease i : notFoundIfNull(releases.get(keyOf(username, name))).values()) {
+            result.add(i.clone());
+        }
+        return result;
+    }
+
+    @Override
+    public List<GiteaRelease> fetchReleases(GiteaRepository repository, boolean draft, boolean prerelease)
+            throws IOException, InterruptedException {
+        return fetchReleases(repository.getOwner().getUsername(), repository.getName(), draft, prerelease);
+    }
+
+    @Override
+    public GiteaRelease.Attachment createReleaseAttachment(String username, String repository, long id, String name, InputStream file)
+            throws IOException, InterruptedException {
+        // TODO
+        return null;
+    }
+
+    @Override
+    public GiteaRelease.Attachment createReleaseAttachment(GiteaRepository repository, long id, String name, InputStream file)
+            throws IOException, InterruptedException {
+        return createReleaseAttachment(repository.getOwner().getUsername(), repository.getName(), id, name, file);
     }
 
     @Override


### PR DESCRIPTION
This PR adds the ability to discover releases in gitea as "branches" to be build seperatly.

It also adds an task for pipelines ("publishGiteaAssets") which works a little like copyArtifacts but uploads artifacts as an asset to the current building release.

The PR also contains an (toggleable) feature to "map" artifacts originally created via copyArtifacts to gitea release assets.

Relevant issues:
- [JENKINS-67790 - Upload built artifacts](https://issues.jenkins.io/browse/JENKINS-67790)

___

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
