### PR TITLE
Handle NOT_BUILT results more clearly

### DIFF
--- a/src/main/java/org/jenkinsci/plugin/gitea/GiteaNotifier.java
+++ b/src/main/java/org/jenkinsci/plugin/gitea/GiteaNotifier.java
@@ -108,7 +108,7 @@ public class GiteaNotifier {
             status.setState(GiteaCommitState.FAILURE);
         } else if (Result.NOT_BUILT.equals(result)) {
             status.setDescription("This commit was not built");
-            status.setState(GiteaCommitState.UNKOWN);
+            status.setState(GiteaCommitState.WARNING);
         } else if (result != null) { // ABORTED etc.
             status.setDescription("Something is wrong with the build of this commit");
             status.setState(GiteaCommitState.ERROR);

--- a/src/main/java/org/jenkinsci/plugin/gitea/GiteaNotifier.java
+++ b/src/main/java/org/jenkinsci/plugin/gitea/GiteaNotifier.java
@@ -106,6 +106,9 @@ public class GiteaNotifier {
         } else if (Result.FAILURE.equals(result)) {
             status.setDescription("There was a failure building this commit");
             status.setState(GiteaCommitState.FAILURE);
+        } else if (Result.NOT_BUILT.equals(result)) {
+            status.setDescription("This commit was not built");
+            status.setState(GiteaCommitState.UNKOWN);
         } else if (result != null) { // ABORTED etc.
             status.setDescription("Something is wrong with the build of this commit");
             status.setState(GiteaCommitState.ERROR);

--- a/src/main/java/org/jenkinsci/plugin/gitea/client/api/GiteaCommitState.java
+++ b/src/main/java/org/jenkinsci/plugin/gitea/client/api/GiteaCommitState.java
@@ -34,7 +34,8 @@ public enum GiteaCommitState {
     SUCCESS("success"),
     ERROR("error"),
     FAILURE("failure"),
-    WARNING("warning");
+    WARNING("warning"),
+    UNKOWN("unknown");
 
     private final String key;
 

--- a/src/main/java/org/jenkinsci/plugin/gitea/client/api/GiteaCommitState.java
+++ b/src/main/java/org/jenkinsci/plugin/gitea/client/api/GiteaCommitState.java
@@ -34,8 +34,7 @@ public enum GiteaCommitState {
     SUCCESS("success"),
     ERROR("error"),
     FAILURE("failure"),
-    WARNING("warning"),
-    UNKOWN("unknown");
+    WARNING("warning");
 
     private final String key;
 


### PR DESCRIPTION
Jenkins job that have Result `NOT_BUILT` are reported as errors which confuses developers.

Context for `NOT_BUILT`: https://github.com/jenkinsci/workflow-job-plugin/pull/200

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
