### PR TITLE
separate the last info section

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -41,7 +41,9 @@
 ### Configure the item
 
 1. When configuring the new item, select "Repository Sources"  
+
 ℹ️ **This is only necessary when using `branch-api` plugin version >=2.7.0**
+
 2. In the "Gitea organzations" section, add a new credential of type "Gitea personal access token".
 3. Add the access token created before for the jenkins user in Gitea. Ignore the error about the token not having the correct length.
 4. In the "Owner" field, add the name of the organization in Gitea you want to build projects for (**not** the full name).


### PR DESCRIPTION
The info section **This is only necessary when using `branch-api` plugin version >=2.7.0** breaks formatting of the main plugin description online. (https://plugins.jenkins.io/gitea/)

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
