### PR TITLE
Fix JENKINS-69719: Fetch PR data from target repo

### DIFF
--- a/src/main/java/org/jenkinsci/plugin/gitea/GiteaSCMFileSystem.java
+++ b/src/main/java/org/jenkinsci/plugin/gitea/GiteaSCMFileSystem.java
@@ -131,9 +131,9 @@ public class GiteaSCMFileSystem extends SCMFileSystem {
             String repository;
             String ref;
             if (head instanceof PullRequestSCMHead) {
-                repoOwner = ((PullRequestSCMHead) head).getOriginOwner();
-                repository = ((PullRequestSCMHead) head).getOriginRepository();
-                ref = ((PullRequestSCMHead) head).getOriginName();
+                repoOwner = src.getRepoOwner();
+                repository = src.getRepository();
+                ref = head.getName();
             } else if (head instanceof BranchSCMHead) {
                 repoOwner = src.getRepoOwner();
                 repository = src.getRepository();


### PR DESCRIPTION
Jenkins token permissions potentially invalid to access source repo.
This is the cause of issue [JENKINS-69719](https://issues.jenkins.io/browse/JENKINS-69719).

All required Gitea Pull Request data can be accessed via target repo.
Replace access to potentially inaccessible source repository by references in target repository Pull Request head.

### Testing done

The change affects token/credential permission scope on the Gitea server.
With the changed source for data access, the `MultiBranchPipeline` scan completes.

Jenkins can pull/checkout (moving) head of pull request.
Resolution to commit hash is done independently in body of `GiteaSCMFileSystem` constructor.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
