### PR TITLE
Fully enable automated releases

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates
+
+version: 2
+updates:
+- package-ecosystem: maven
+  directory: /
+  schedule:
+    interval: monthly
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: monthly

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -1,75 +1,17 @@
 name: cd
 on:
   workflow_dispatch:
+  check_run:
+    types:
+      - completed
+
+permissions:
+  checks: read
+  contents: write
 
 jobs:
-  validate:
-    runs-on: ubuntu-latest
-    outputs:
-      should_release: ${{ steps.verify-ci-status.outputs.result == 'success' && steps.interesting-categories.outputs.interesting == 'true' }}
-    steps:
-      - name: Verify CI status
-        uses: jenkins-infra/verify-ci-status-action@v1.2.1
-        id: verify-ci-status
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          output_result: true
-
-      - name: Release Drafter
-        uses: release-drafter/release-drafter@v5
-        id: draft
-        if: steps.verify-ci-status.outputs.result == 'success'
-        with:
-          name: next
-          tag: next
-          version: next
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Check interesting categories
-        uses: jenkins-infra/interesting-category-action@v1.2.0
-        id: interesting-categories
-        if: steps.verify-ci-status.outputs.result == 'success'
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_DRAFT_BODY: ${{ steps.draft.outputs.body }}
-
-  release:
-    runs-on: ubuntu-latest
-    needs: [validate]
-    if: needs.validate.outputs.should_release == 'true'
-    steps:
-    - name: Check out
-      uses: actions/checkout@v2.3.4
-      with:
-        fetch-depth: 0
-    - name: Set up JDK 8
-      uses: actions/setup-java@v2
-      with:
-        distribution: 'adopt'
-        java-version: 8
-    - name: Release
-      uses: justusbunsi/jenkins-maven-cd-action@v1.2.1
-      with:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
-        MAVEN_TOKEN: ${{ secrets.MAVEN_TOKEN }}
-        NO_CHANGELIST: '1'
-    - name: Setup Git user
-      run: |
-        git config --local user.name "github-actions[bot]"
-        git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
-    - name: Lock auto-incremented version
-      run: |
-        mvn -B -ntp -DgenerateBackupPoms=false -Drevision=$(mvn -B -ntp -Dchangelist= -Dexpression=project.version -q -DforceStdout help:evaluate) release:update-versions
-        mvn -B -ntp -Dignore.dirt incrementals:reincrementalify
-        git add pom.xml
-        git commit -m "[github-action] prepare for next development iteration"
-    - name: Create Pull Request
-      uses: peter-evans/create-pull-request@v3
-      with:
-        title: '[github-action] Bump version'
-        body: ""
-        labels: "skip-changelog"
-        signoff: false
-        delete-branch: true
+  maven-cd:
+    uses: jenkins-infra/github-reusable-workflows/.github/workflows/maven-cd.yml@v1
+    secrets:
+      MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
+      MAVEN_TOKEN: ${{ secrets.MAVEN_TOKEN }}

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,2 +1,3 @@
 -Pconsume-incrementals
 -Pmight-produce-incrementals
+-Dchangelist.format=%d.v%s

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>gitea</artifactId>
-    <version>${revision}${changelist}</version>
+    <version>${changelist}</version>
     <packaging>hpi</packaging>
 
     <name>Gitea Plugin</name>
@@ -30,8 +30,7 @@
     </scm>
 
     <properties>
-        <revision>1.4.8</revision>
-        <changelist>-SNAPSHOT</changelist>
+        <changelist>999999-SNAPSHOT</changelist>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine>
         <jenkins.version>2.426.3</jenkins.version>


### PR DESCRIPTION
Most of the plugins I use fully migrated to JEP-229[^1]. It seems stable enough and reduces manual overhead when releasing the plugin.

After quick chat with @lafriks in Discord, we decided to fully enable automated releases. The first part happened in #35. I followed the official docs[^2]. This will eliminate the version bump PR after each release.

This will change the versioning pattern to `<amount-of-commits-on-main-branch>.v<HEAD>`. When the next release is crafted, we should add a note to the release about this version change.

I also configured Dependabot to get monthly updates for our dependencies.

[^1]: https://github.com/jenkinsci/jep/blob/master/jep/229/README.adoc
[^2]: https://www.jenkins.io/doc/developer/publishing/releasing-cd/