### PR TITLE
Migrate from EE 8 to EE 9

### DIFF
--- a/src/main/java/org/jenkinsci/plugin/gitea/GiteaBrowser.java
+++ b/src/main/java/org/jenkinsci/plugin/gitea/GiteaBrowser.java
@@ -38,7 +38,7 @@ import net.sf.json.JSONObject;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugin.gitea.servers.GiteaServers;
 import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 
 /**
  * A {@link GitRepositoryBrowser} for Gitea.
@@ -143,7 +143,7 @@ public class GiteaBrowser extends GitRepositoryBrowser {
          * {@inheritDoc}
          */
         @Override
-        public GiteaBrowser newInstance(StaplerRequest req, JSONObject jsonObject) throws FormException {
+        public GiteaBrowser newInstance(StaplerRequest2 req, JSONObject jsonObject) throws FormException {
             return req.bindJSON(GiteaBrowser.class, jsonObject);
         }
     }

--- a/src/main/java/org/jenkinsci/plugin/gitea/GiteaLink.java
+++ b/src/main/java/org/jenkinsci/plugin/gitea/GiteaLink.java
@@ -87,7 +87,7 @@ public class GiteaLink implements Action, IconSpec {
             Icon icon = IconSet.icons.getIconByClassSpec(iconClassName + " icon-md");
             if (icon != null) {
                 JellyContext ctx = new JellyContext();
-                ctx.setVariable("resURL", Stapler.getCurrentRequest().getContextPath() + Jenkins.RESOURCE_PATH);
+                ctx.setVariable("resURL", Stapler.getCurrentRequest2().getContextPath() + Jenkins.RESOURCE_PATH);
                 return icon.getQualifiedUrl(ctx);
             }
         }

--- a/src/main/java/org/jenkinsci/plugin/gitea/GiteaWebhookAction.java
+++ b/src/main/java/org/jenkinsci/plugin/gitea/GiteaWebhookAction.java
@@ -28,17 +28,17 @@ import hudson.ExtensionList;
 import hudson.model.UnprotectedRootAction;
 import hudson.security.csrf.CrumbExclusion;
 import hudson.util.HttpResponses;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import jenkins.scm.api.SCMEvent;
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.HttpResponse;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 
 @Extension
 public class GiteaWebhookAction extends CrumbExclusion implements UnprotectedRootAction {
@@ -70,7 +70,7 @@ public class GiteaWebhookAction extends CrumbExclusion implements UnprotectedRoo
         return false;
     }
 
-    public HttpResponse doPost(StaplerRequest request) throws IOException {
+    public HttpResponse doPost(StaplerRequest2 request) throws IOException {
         String origin = SCMEvent.originOf(request);
         if (!request.getMethod().equals("POST")) {
             LOGGER.log(Level.FINE, "Received {0} request (expecting POST) from {1}",

--- a/src/main/java/org/jenkinsci/plugin/gitea/servers/GiteaServers.java
+++ b/src/main/java/org/jenkinsci/plugin/gitea/servers/GiteaServers.java
@@ -43,7 +43,7 @@ import jenkins.model.GlobalConfiguration;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 import org.apache.commons.lang.StringUtils;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 
 /**
  * Represents the global configuration of Gitea servers.
@@ -214,7 +214,7 @@ public class GiteaServers extends GlobalConfiguration {
      * {@inheritDoc}
      */
     @Override
-    public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
+    public boolean configure(StaplerRequest2 req, JSONObject json) throws FormException {
         req.bindJSON(this, json);
         return true;
     }

--- a/src/main/java/org/jenkinsci/plugin/gitea/tasks/GiteaAssetPublisher.java
+++ b/src/main/java/org/jenkinsci/plugin/gitea/tasks/GiteaAssetPublisher.java
@@ -71,7 +71,7 @@ import org.jenkinsci.plugin.gitea.ReleaseSCMHead;
 import org.jenkinsci.plugin.gitea.client.api.GiteaConnection;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 
 public class GiteaAssetPublisher implements SimpleBuildStep, Describable<GiteaAssetPublisher> {
 
@@ -311,7 +311,7 @@ public class GiteaAssetPublisher implements SimpleBuildStep, Describable<GiteaAs
         }
 
         @Override
-        public GiteaAssetPublisher newInstance(@NonNull StaplerRequest req, JSONObject formData) throws FormException {
+        public GiteaAssetPublisher newInstance(@NonNull StaplerRequest2 req, JSONObject formData) throws FormException {
             return req.bindJSON(GiteaAssetPublisher.class, formData);
         }
 


### PR DESCRIPTION
Migrate from deprecated EE 8 functionality to non-deprecated EE 9 equivalents.

### Testing done

`mvn clean verify`