### PR TITLE
Support withCredentials on PersonalAccessToken(Impl)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,11 @@
             <artifactId>workflow-multibranch</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+          <groupId>org.jenkins-ci.plugins.workflow</groupId>
+          <artifactId>workflow-basic-steps</artifactId>
+          <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <repositories>

--- a/src/main/java/org/jenkinsci/plugin/gitea/credentials/PersonalAccessTokenBinding.java
+++ b/src/main/java/org/jenkinsci/plugin/gitea/credentials/PersonalAccessTokenBinding.java
@@ -1,0 +1,78 @@
+package org.jenkinsci.plugin.gitea.credentials;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import hudson.Extension;
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.util.Secret;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import org.jenkinsci.Symbol;
+import org.jenkinsci.plugins.credentialsbinding.BindingDescriptor;
+import org.jenkinsci.plugins.credentialsbinding.MultiBinding;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+public class PersonalAccessTokenBinding extends MultiBinding<PersonalAccessToken> {
+
+    // Environment variable name to be used in the binding
+    private final String variable;
+
+    @DataBoundConstructor
+    public PersonalAccessTokenBinding(String credentialsId, String variable) {
+        super(credentialsId);
+        this.variable = variable;
+    }
+
+    @Override
+    protected Class<PersonalAccessToken> type() {
+        return PersonalAccessToken.class;
+    }
+
+    @Override
+    public Set<String> variables() {
+        // Return a set containing the environment variable name
+        return Collections.singleton(variable);
+    }
+
+    @Override
+    public MultiEnvironment bind(
+            @NonNull Run<?, ?> build,
+            @Nullable FilePath workspace,
+            @Nullable Launcher launcher,
+            @NonNull TaskListener listener)
+            throws IOException, InterruptedException {
+        // Retrieve the PersonalAccessToken credentials
+        PersonalAccessToken credentials = getCredentials(build);
+
+        Map<String, String> values = new LinkedHashMap<>();
+        values.put(variable, Secret.toString(credentials.getToken()));
+        return new MultiEnvironment(values);
+    }
+
+    @Symbol("giteaPersonalAccessToken") // Symbol annotation for use in Jenkins UI
+    @Extension
+    public static class DescriptorImpl extends BindingDescriptor<PersonalAccessTokenImpl> {
+
+        @Override
+        protected Class<PersonalAccessTokenImpl> type() {
+            return PersonalAccessTokenImpl.class;
+        }
+
+        @NonNull
+        @Override
+        public String getDisplayName() {
+            return Messages.PersonalAccessTokenImpl_displayName(); // Localized display name
+        }
+
+        @Override
+        public boolean requiresWorkspace() {
+            return false; // This binding does not require a workspace
+        }
+    }
+}

--- a/src/test/java/org/jenkinsci/plugin/gitea/credentials/PersonalAccessTokenBindingTest.java
+++ b/src/test/java/org/jenkinsci/plugin/gitea/credentials/PersonalAccessTokenBindingTest.java
@@ -1,0 +1,58 @@
+package org.jenkinsci.plugin.gitea.credentials;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import org.apache.commons.io.IOUtils;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.CredentialsStore;
+import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
+import com.cloudbees.plugins.credentials.domains.Domain;
+
+import hudson.model.Run;
+
+@WithJenkins
+class PersonalAccessTokenBindingTest {
+
+    private static final String API_TOKEN = "secret";
+    private static final String API_TOKEN_ID = "personalAccessTokenId";
+
+    private JenkinsRule jenkins;
+
+    @BeforeEach
+    void setUp(JenkinsRule rule) throws Exception {
+        jenkins = rule;
+        for (CredentialsStore credentialsStore : CredentialsProvider.lookupStores(jenkins.jenkins)) {
+            if (credentialsStore instanceof SystemCredentialsProvider.StoreImpl) {
+                List<Domain> domains = credentialsStore.getDomains();
+                credentialsStore.addCredentials(
+                        domains.get(0),
+                        new PersonalAccessTokenImpl(
+                                CredentialsScope.GLOBAL,
+                                API_TOKEN_ID,
+                                "Gitea Personal Access Token",
+                                API_TOKEN));
+            }
+        }
+    }
+
+    @Test
+    void withCredentials_success() throws Exception {
+        WorkflowJob project = jenkins.createProject(WorkflowJob.class);
+        String pipelineText = IOUtils.toString(
+                getClass().getResourceAsStream("pipeline/withCredentials-pipeline.groovy"), StandardCharsets.UTF_8);
+        project.setDefinition(new CpsFlowDefinition(pipelineText, false));
+        Run<?, ?> build = jenkins.buildAndAssertSuccess(project);
+        // assert false to know we run it in tests
+        jenkins.assertLogContains("Token1 is ecret", build);
+        jenkins.assertLogContains("Token2 is ecret", build);
+    }
+}

--- a/src/test/resources/org/jenkinsci/plugin/gitea/credentials/pipeline/withCredentials-pipeline.groovy
+++ b/src/test/resources/org/jenkinsci/plugin/gitea/credentials/pipeline/withCredentials-pipeline.groovy
@@ -1,0 +1,17 @@
+package org.jenkinsci.plugin.gitea.credentials.pipeline
+
+node {
+    withCredentials([[
+        $class: 'org.jenkinsci.plugin.gitea.credentials.PersonalAccessTokenBinding',
+        credentialsId: "personalAccessTokenId",
+        variable: "API_TOKEN1"
+    ]]) {
+        println "Token1 is ${API_TOKEN1.substring(1)}"
+    }
+    withCredentials([giteaPersonalAccessToken(
+        credentialsId: "personalAccessTokenId",
+        variable: "API_TOKEN2"
+    )]) {
+        println "Token2 is ${API_TOKEN2.substring(1)}"
+    }
+}


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

Fixes [JENKINS-75582](https://issues.jenkins.io/browse/JENKINS-75582)

`MultiBinding ` implementation for the PersonalAccessTokenImpl class PersonalAccessToken interface.

### Testing done

A test was introduced to run the complete pipeline and validate withCredentials, using both the full `$class` syntax and the `personalAccessTokenId `binding.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
