### PR TITLE
Change GiteaNotifier to set commit status to FAILURE for unstable builds

### DIFF
--- a/src/main/java/org/jenkinsci/plugin/gitea/GiteaNotifier.java
+++ b/src/main/java/org/jenkinsci/plugin/gitea/GiteaNotifier.java
@@ -105,7 +105,7 @@ public class GiteaNotifier {
                 status.setState(GiteaCommitState.SUCCESS);
             } else if (Result.UNSTABLE.equals(result)) {
                 status.setDescription("This commit is unstable");
-                status.setState(GiteaCommitState.WARNING);
+                status.setState(GiteaCommitState.FAILURE);
             } else if (Result.FAILURE.equals(result)) {
                 status.setDescription("There was a failure building this commit");
                 status.setState(GiteaCommitState.FAILURE);


### PR DESCRIPTION
As Gitea doesn't block merges anymore on "Warning" Status a PR could be merged even though the build was unstable.
To prevent this we need to report unstable as a failure

https://github.com/go-gitea/gitea/issues/37042

### Testing done


### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

